### PR TITLE
Changed mongo keys from unicode to str

### DIFF
--- a/resolwe_bio/tools/utils.py
+++ b/resolwe_bio/tools/utils.py
@@ -13,4 +13,4 @@ def gzopen(fname):
 
 def escape_mongokey(key):
     """Escape keys when serializing database entries"""
-    return str(key.replace('$', u'\uff04').replace('.', u'\uff0e').replace(' ', '_'))
+    return key.replace('$', '\uff04').replace('.', '\uff0e').replace(' ', '_')


### PR DESCRIPTION
Redis would fail for spawn processes with unicode dict keys.