### PR TITLE
Fix merging columns of different types

### DIFF
--- a/resolwe_bio/tools/transmart_utils.py
+++ b/resolwe_bio/tools/transmart_utils.py
@@ -74,7 +74,7 @@ def format_annotations(annfile):
     # create var template
     var_template = []
     attrs_final = sorted(attrs_final)
-    attrs_final_keys = map(utils.escape_mongokey, attrs_final)
+    attrs_final_keys = map(lambda x: utils.escape_mongokey(x).encode('unicode_escape'), attrs_final)
     dtype = dict(annp.dtype.descr)
     dtype_final = []
 
@@ -92,7 +92,7 @@ def format_annotations(annfile):
 
         field, field_type = None, None
         field = {
-            'name': utils.escape_mongokey(attr_name),
+            'name': utils.escape_mongokey(attr_name).encode('unicode_escape'),
             'label': label,
         }
 

--- a/resolwe_bio/tools/utils.py
+++ b/resolwe_bio/tools/utils.py
@@ -13,4 +13,4 @@ def gzopen(fname):
 
 def escape_mongokey(key):
     """Escape keys when serializing database entries"""
-    return key.replace('$', '\uff04').replace('.', '\uff0e').replace(' ', '_')
+    return key.replace('$', u'\uff04').replace('.', u'\uff0e').replace(' ', '_')


### PR DESCRIPTION
We merge attributes that were binarized by tranSMART into one attribute. Fox example, tranSMART creates 2 attribtes for sex, _i.e._ ```sex_M``` and ```sex_F``` with values ```{'M' or ''}``` and ```{'F' or ''}```, respectively. Sometimes those binary attributes are of different types. For example, ```Non.Allergic.Rhinitis.Active_0``` and ```Non.Allergic.Rhinitis.Active_NA``` have values ```{-1 or 0}``` and ```{'NA' or ''}```, respectively.

This fix converts such mixed binary attributes to strings before they are to be merged.