### PR TITLE
WIP: Enable VC filtering test (chemical mutagenesis)

### DIFF
--- a/resolwe_bio/processes/variant_calling/VC_filtering.yml
+++ b/resolwe_bio/processes/variant_calling/VC_filtering.yml
@@ -127,7 +127,13 @@
 
       cp {{variants.vcf.file}} .
 
-      Rscript -e 'source("{{ proc.slugs_path }}/Cheng-Lin-chemical_mutagenesis/R/{{analysis_type}}.R")' -e '{{analysis_type}}(input_file = "'${NAME}.vcf'", ref_file = "{{ proc.slugs_path }}/Cheng-Lin-chemical_mutagenesis/reference_files/", parental_strain = "{{parental_strain}}", mutant_strain = "{{mutant_strain}}", read_depth = '{{read_depth}}')'
+      # XXX: Ugly hack to make this also work on the legacy platform
+      # TODO: Generalize the concept of auxiliary data
+      if [[ -z "{{ proc.slugs_path }}" ]]; then
+        Rscript -e '{{analysis_type}}(input_file = "'${NAME}.vcf'", ref_file = "/home/biolinux/auxiliary_data/chemical_mutagenesis/", parental_strain = "{{parental_strain}}", mutant_strain = "{{mutant_strain}}", read_depth = '{{read_depth}}')'
+      else
+        Rscript -e 'source("{{ proc.slugs_path }}/Cheng-Lin-chemical_mutagenesis/R/{{analysis_type}}.R")' -e '{{analysis_type}}(input_file = "'${NAME}.vcf'", ref_file = "{{ proc.slugs_path }}/Cheng-Lin-chemical_mutagenesis/reference_files/", parental_strain = "{{parental_strain}}", mutant_strain = "{{mutant_strain}}", read_depth = '{{read_depth}}')'
+      fi
       re-checkrc "VCF file filtering failed"
       re-progress 0.9
 

--- a/resolwe_bio/tests/test_variant_calling.py
+++ b/resolwe_bio/tests/test_variant_calling.py
@@ -59,7 +59,6 @@ class VariantCallingTestCase(BioProcessTestCase):
         self.run_processor('vc-gatk-joint', inputs)
         # NOTE: output can not be tested
 
-    @unittest.skip("Missing tools in runtime")
     def test_vc_filtering(self):
         variants = self.run_processor('import:upload:variants-vcf', {'src': 'variant_calling_filtering.vcf.gz'})
 


### PR DESCRIPTION
## WIP
- Remove the ugly hack which makes this also work on the legacy platform.

## TODO

- [ ] Generalize the concept of auxiliary data.

## Notes
- Run the test with:
  ` ./tests/manage.py test -v 2 resolwe_bio.tests.test_variant_calling.VariantCallingTestCase.test_vc_filtering`
- If the test passes, you should get an output similar to:
```
(resolwe)[tadej@tlinux64 resolwe-bio (fix-vc_filtering_docker)]$ ./tests/manage.py test -v 2 resolwe_bio.tests.test_variant_calling.VariantCallingTestCase.test_vc_filtering
/home/tadej/.virtualenvs/resolwe/lib/python2.7/site-packages/six.py:824: RemovedInDjango110Warning: SubfieldBase has been deprecated. Use Field.from_db_value instead.
  return metaclass(cls.__name__, cls.__bases__, orig_vars)

Creating test database for alias 'default' ('resolwe-bio_test')...
Operations to perform:
  Synchronize unmigrated apps: mathfilters, staticfiles, versionfield, resolwe_bio, rest_framework, resolwe, permissions
  Apply all migrations: sessions, apps, flow, auth, contenttypes, guardian
Synchronizing apps without migrations:
  Creating tables...
    Running deferred SQL...
Running migrations:
  Rendering model states... DONE
  Applying contenttypes.0001_initial... OK
  Applying auth.0001_initial... OK
  Applying flow.0001_initial... OK
  Applying apps.0001_initial... OK
  Applying contenttypes.0002_remove_content_type_name... OK
  Applying auth.0002_alter_permission_name_max_length... OK
  Applying auth.0003_alter_user_email_max_length... OK
  Applying auth.0004_alter_user_username_opts... OK
  Applying auth.0005_alter_user_last_login_null... OK
  Applying auth.0006_require_contenttypes_0002... OK
  Applying auth.0007_alter_validators_add_error_messages... OK
  Applying guardian.0001_initial... OK
  Applying sessions.0001_initial... OK
test_vc_filtering (resolwe_bio.tests.test_variant_calling.VariantCallingTestCase) ... Processor Updates:
  Inserted alignment-bwa_mem-075a
  Inserted alignment-bwa_sw-075a
  Inserted alignment-bwa_aln-075a
  Inserted alignment-star
  Inserted alignment-star-index
  Inserted alignment-bowtie-1-0-0-trimmx
  Inserted alignment-bowtie-2-2-3_trim
  Inserted alignment-tophat-2-0-13
  Inserted assembler-abyss
  Inserted jbrowse-refseq
  Inserted jbrowse-gtf
  Inserted jbrowse-bam-coverage
  Inserted jbrowse-bed
  Inserted jbrowse-gff3
  Inserted jbrowse-bam-coverage-normalized
  Inserted vcf-annotation
  Inserted vc-gatk-joint
  Inserted vc-samtools
  Inserted vc-gatk
  Inserted vc_filtering_chem_mutagenesis
  Inserted import-web-transmart-expressions
  Inserted goenrichment-bcm-2-0-0
  Inserted filtering-fastq-mcf-112537-single-end
  Inserted filtering-fastq-mcf-112537-paired-end
  Inserted reads-merge
  Inserted filtering-prinseq-lite-204-single-end
  Inserted filtering-prinseq-lite-204-paired-end
  Inserted filtering-sortmerna-20-single-end
  Inserted filtering-sortmerna-20-paired-end
  Inserted test-basic-fields
  Inserted test-list
  Inserted test-sleep-progress
  Inserted test-disabled
  Inserted test-hidden
  Inserted differentialexpression-limma
  Inserted differentialexpression-bcm-1-0-0
  Inserted cuffdiff-2-2-1
  Inserted differentialexpression-deseq2
  Inserted microarray-affy-qc
  Inserted pca-1-0-0
  Inserted findsimilar
  Inserted clustering-hierarchical-bcm-1-0-0
  Inserted chipseq-peakscore
  Inserted chipseq-genescore
  Inserted macs2-callpeak
  Inserted bam-coverage
  Inserted reference_compatibility
  Inserted cuffquant-2-2-1
  Inserted summarizexpressions-ncrna
  Inserted cuffnorm-2-2-1
  Inserted kallisto-quant
  Inserted kallisto-index
  Inserted htseq-count-0-6-1p1
  Inserted mappability-bcm-1-0-0
  Inserted mergeetc
  Inserted cufflinks-2-2-1
  Inserted mergeexpressions
  Inserted etc-bcm-1-0-0
  Inserted expression-bcm-ncrna
  Inserted expression-bcm-1-0-0
  Inserted import-upload-genome-fasta
  Inserted import-upload-variants-vcf
  Inserted import-upload-gaf
  Inserted import-upload-mapping-bam
  Inserted import-upload-mapping-bam-indexed
  Inserted import-upload-import_nucl_seq
  Inserted import-upload-diffexp
  Inserted import-upload-bed
  Inserted import-upload-variants-bed
  Inserted import-upload-mappability
  Inserted import-upload-hmmer_database
  Inserted import-upload-etc
  Inserted import-upload-mappability-bigwig
  Inserted import-upload-ontology
  Inserted import-upload-rmsk-annotation
  Inserted import-upload-reads-fastq
  Inserted import-upload-reads-fastq-paired-end
  Inserted import-web-gtf-bcm-1-0-0
  Inserted import-upload-multiplexed
  Inserted import-upload-multiplexed-paired-end
  Inserted import-upload-geneinfo
  Inserted import-upload-microarray-affy
  Inserted import-upload-orthologues
  Inserted import-web-geneinfo-hsapiens
  Inserted import-upload-annotation-gff3
  Inserted import-upload-annotation-gtf
  Inserted import-web-geneinfo-dictyostelium
  Inserted import-upload-expression
  Inserted import-web-geneinfo-mus
  Inserted import-web-geneinfo-mm10
  Inserted feature_location
  Inserted cuffmerge-gtf-to-gff3
  Inserted cuffmerge-2-2-1
  Inserted transdecoder
  Inserted coverage-garvan
ok

----------------------------------------------------------------------
Ran 1 test in 14.550s

OK
Destroying test database for alias 'default' ('resolwe-bio_test')...
```