### PR TITLE
Make Tox configuration more robust to different developer environments

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -9,6 +9,10 @@ All notable changes to this project are documented in this file.
 Unreleased
 ==========
 
+Fixed
+-----
+* Make Tox configuration more robust to different developer environments
+
 Added
 -----
 * ``skipDockerFailure`` test decorator

--- a/tox.ini
+++ b/tox.ini
@@ -13,14 +13,14 @@ commands =
 # install testing requirements
 # NOTE: Don't use 'deps = .[test]' tox option since we want Tox to install the
 # package from sdist first
-    pip install .[test]
+    pip install --process-dependency-links .[test]
 # confirm that items checked into git are in sdist
     check-manifest
 # verify package metadata and confirm the long_description will render
 # correctly on PyPI
     python setup.py check --metadata --restructuredtext --strict
 # pull Docker image manually to prevent skewing the time needed by first test
-    bash -c \'docker pull $(python -c \
+    bash -c \'{env:RESOLWE_EXECUTOR_COMMAND:docker} pull $(python -c \
         "from django.conf import settings; \
          print(settings.FLOW_EXECUTOR[\"CONTAINER_IMAGE\"])" \
     )\'
@@ -32,4 +32,4 @@ setenv =
     DJANGO_SETTINGS_MODULE=tests.settings
 # it is necessary to explicitly list the environment variables that need to be
 # passed from Tox's invocation environment to the testing environment
-passenv = TOXENV RESOLWE_POSTGRESQL_* DOCKER_*
+passenv = TOXENV RESOLWE_* RESOLWEBIO_* DOCKER_*


### PR DESCRIPTION
Add `--process-dependency-links` to Tox's pip install command to ensure a developer can easily bump a dependency to the latest git version while developing on a personal feature branch.
Make command that pulls Docker images aware of the `RESOLWE_EXECUTOR_COMMAND` environment variable.
Change the wildcard to pass all environment variables starting with `RESOLWE_` or `RESOLWEBIO_` to Tox's testing environment.