### PR TITLE
Change default PostgreSQL port to avoid a collision with Resolwe

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -7,4 +7,4 @@ postgresql:
         POSTGRES_USER: resolwe
         POSTGRES_DB: resolwe-bio
     ports:
-        - "55432:5432"
+        - "55433:5432"

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -67,7 +67,7 @@ toxenv = os.environ.get('TOXENV', '')
 pgname = os.environ.get('RESOLWE_POSTGRESQL_NAME', 'resolwe-bio')
 pguser = os.environ.get('RESOLWE_POSTGRESQL_USER', 'resolwe')
 pghost = os.environ.get('RESOLWE_POSTGRESQL_HOST', 'localhost')
-pgport = int(os.environ.get('RESOLWE_POSTGRESQL_PORT', 55432))
+pgport = int(os.environ.get('RESOLWE_POSTGRESQL_PORT', 55433))
 
 DATABASES = {
     'default': {


### PR DESCRIPTION
Change default PostgreSQL port to 55433 to avoid a collision with
Resolwe's default PostgreSQL port. If a developer wants to use
docker-compose with each project's default configuration, this is now
possible since the projects' docker-compose settings don't interfere
anymore.