### PR TITLE
Add raw Gene Info processor

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -37,6 +37,7 @@ Fixed
 * Make Tox configuration more robust to different developer environments
 * Set ``required: false`` in processor input/output fields where necessary
 * Add ``Sample``'s ``Data objects`` to ``Collection`` when ``Sample`` is added
+* Add raw Gene Info process
 
 Added
 -----

--- a/resolwe_bio/processes/import_data/gene_info_raw.yml
+++ b/resolwe_bio/processes/import_data/gene_info_raw.yml
@@ -1,0 +1,31 @@
+# ========================
+# Import - Gene Info - Raw
+# ========================
+---
+
+- slug: upload-geneinfo-raw
+  name: Upload gene information raw
+  data_name: '{{ src.file|default:"?" }}'
+  version: 1.0.0
+  type: data:geneinfo:raw
+  category: upload
+  persistence: RAW
+  description: >
+    Upload gene information from text file.
+  input:
+    - name: src
+      label: Gene information
+      type: basic:file
+      description: >
+        Gene information in tab-separated text file. Composition: first row is a header (ID, Gene Name, Official name, Synonyms, Organism, Description, Entrez ID, OMIM ID, UniprotKB ID, Ensembl ID, MGI ID) followed by rows. Supported extensions: .tab, .txt.
+      validate_regex: '\.(tab|txt)$'
+  output:
+    - name: src
+      label: Gene information
+      type: basic:file
+  run:
+    runtime: polyglot
+    bash: |
+      re-import "{{ src.file_temp|default:src.file }}" "{{ src.file }}" "txt|tab" "tab" 0.8
+
+      re-save-file src ${NAME}.tab


### PR DESCRIPTION
This processor just saves the uploaded file

Intended to be used with [gene_info.tab](https://data.genialis.com/seafhttp/files/fb4c99a4/gene_info.tab) in Gene Info widget