### PR TITLE
Fix kb serializer

### DIFF
--- a/resolwe_bio/kb/serializers.py
+++ b/resolwe_bio/kb/serializers.py
@@ -19,3 +19,4 @@ class FeatureSerializer(serializers.ModelSerializer):
         """Serializer configuration."""
 
         model = Feature
+        fields = '__all__'


### PR DESCRIPTION
After upgrading `django-rest-framework`, tests are failing with:

    AssertionError: (u"Creating a ModelSerializer without either the 'fields' attribute or the 'exclude' attribute has been deprecated since 3.3.0, and is now disallowed. Add an explicit fields = '__all__' to the FeatureSearchSerializer serializer.",)