### PR TITLE
Update pycodestyle config

### DIFF
--- a/resolwe_bio/expression_filters/sample.py
+++ b/resolwe_bio/expression_filters/sample.py
@@ -38,6 +38,7 @@ def sample_name(data):
     """Return `name` of `Sample` that given `Data` object belongs to."""
     return get_sample_attr(data, 'name')
 
+
 # A dictionary of filters that will be registered.
 filters = {  # pylint: disable=invalid-name
     'sample_id': sample_id,

--- a/resolwe_bio/management/commands/generate_diffexpr_cuffdiff.py
+++ b/resolwe_bio/management/commands/generate_diffexpr_cuffdiff.py
@@ -142,20 +142,21 @@ class Command(BaseCommand):
 
         with gzip.open(gene_ids, mode='rt') as gene_ids:
             all_genes = [line.strip() for line in gene_ids]
+            n_of_genes = len(all_genes)
             de_data['test_id'] = all_genes
             de_data['gene_id'] = all_genes
             de_data['gene'] = all_genes
-            de_data['locus'] = ['chr20:463337-524482' for gene in all_genes]
-            de_data['sample_1'] = ['control' for gene in all_genes]
-            de_data['sample_2'] = ['case' for gene in all_genes]
-            de_data['status'] = ['OK' for gene in all_genes]
-            de_data['value_1'] = [random.gammavariate(1, 100) for gene in all_genes]
-            de_data['value_2'] = [random.gammavariate(1, 100) for gene in all_genes]
-            de_data['log2(fold_change)'] = [random.uniform(-10, 10) for gene in all_genes]
-            de_data['test_stat'] = [random.uniform(-3, 3) for gene in all_genes]
-            de_data['p_value'] = [random.uniform(0, 1) for gene in all_genes]
-            de_data['q_value'] = [random.uniform(0, 1) for gene in all_genes]
-            de_data['significant'] = [random.choice(['yes', 'no']) for gene in all_genes]
+            de_data['locus'] = ['chr20:463337-524482'] * n_of_genes
+            de_data['sample_1'] = ['control'] * n_of_genes
+            de_data['sample_2'] = ['case'] * n_of_genes
+            de_data['status'] = ['OK'] * n_of_genes
+            de_data['value_1'] = [random.gammavariate(1, 100) for _ in all_genes]
+            de_data['value_2'] = [random.gammavariate(1, 100) for _ in all_genes]
+            de_data['log2(fold_change)'] = [random.uniform(-10, 10) for _ in all_genes]
+            de_data['test_stat'] = [random.uniform(-3, 3) for _ in all_genes]
+            de_data['p_value'] = [random.uniform(0, 1) for _ in all_genes]
+            de_data['q_value'] = [random.uniform(0, 1) for _ in all_genes]
+            de_data['significant'] = [random.choice(['yes', 'no']) for _ in all_genes]
 
             rows = zip(de_data['test_id'], de_data['gene_id'], de_data['gene'],
                        de_data['locus'], de_data['sample_1'], de_data['sample_2'],

--- a/resolwe_bio/management/commands/generate_diffexpr_deseq.py
+++ b/resolwe_bio/management/commands/generate_diffexpr_deseq.py
@@ -143,12 +143,12 @@ class Command(BaseCommand):
         with gzip.open(gene_ids, mode='rt') as gene_ids:
             all_genes = [line.strip() for line in gene_ids]
             de_data[''] = all_genes
-            de_data['baseMean'] = [random.uniform(5, 500) for gene in all_genes]
-            de_data['log2FoldChange'] = [random.uniform(-10, 10) for gene in all_genes]
-            de_data['lfcSE'] = [random.uniform(0, 1) for gene in all_genes]
-            de_data['stat'] = [random.uniform(-10, 10) for gene in all_genes]
-            de_data['pvalue'] = [random.uniform(0, 1) for gene in all_genes]
-            de_data['padj'] = [random.uniform(0, 1) for gene in all_genes]
+            de_data['baseMean'] = [random.uniform(5, 500) for _ in all_genes]
+            de_data['log2FoldChange'] = [random.uniform(-10, 10) for _ in all_genes]
+            de_data['lfcSE'] = [random.uniform(0, 1) for _ in all_genes]
+            de_data['stat'] = [random.uniform(-10, 10) for _ in all_genes]
+            de_data['pvalue'] = [random.uniform(0, 1) for _ in all_genes]
+            de_data['padj'] = [random.uniform(0, 1) for _ in all_genes]
 
             rows = zip(de_data[''], de_data['baseMean'], de_data['log2FoldChange'],
                        de_data['lfcSE'], de_data['stat'], de_data['pvalue'], de_data['padj'])

--- a/resolwe_bio/tools/build_gene_info_hsapiens.py
+++ b/resolwe_bio/tools/build_gene_info_hsapiens.py
@@ -43,9 +43,9 @@ with open(args.gene_info) as gene_info:
 
 with open(args.uniprotKB) as uniprot:
     for line in uniprot:
-        l = line.split('\t')
-        if l[2] != '':
-            EntrezID2UniprotKB[l[2]] = l[0]
+        line = line.split('\t')
+        if line[2] != '':
+            EntrezID2UniprotKB[line[2]] = line[0]
 
 with open(args.output, "w") as f:
     f.write('\t'.join(["Gene ID", "Gene Name", "Synonyms", "Gene Products", "Entrez ID",

--- a/resolwe_bio/tools/build_gene_info_mus.py
+++ b/resolwe_bio/tools/build_gene_info_mus.py
@@ -42,8 +42,8 @@ with open(args.gene_info) as gene_info:
 
 with open(args.mgi) as mgi:
     for line in mgi:
-        l = line.split('\t')
-        GeneID2mgi[l[5]] = l[0]
+        line = line.split('\t')
+        GeneID2mgi[line[5]] = line[0]
 
 with open(args.output, "w") as f:
     f.write('\t'.join(["Gene ID", "Gene Name", "Synonyms", "Gene Products", "Entrez ID",

--- a/resolwe_bio/tools/demultiplex.py
+++ b/resolwe_bio/tools/demultiplex.py
@@ -69,16 +69,17 @@ def isnum(number):
     except ValueError:
         return False
 
+
 barcode_length = 0
 
 if args.mapping:
     with open(args.mapping, 'rU') as fd:
-        for l in fd:
-            l = l.rstrip()
-            if not l:
+        for line in fd:
+            line = line.rstrip()
+            if not line:
                 continue
 
-            t = l.split('\t')
+            t = line.split('\t')
             barcode, filename = '', ''
 
             if len(t) == 2:

--- a/resolwe_bio/tools/expression2storage.py
+++ b/resolwe_bio/tools/expression2storage.py
@@ -32,6 +32,7 @@ def isfloat(value):
     except ValueError:
         return False
 
+
 with utils.gzopen(args.input) as f:
     # Split lines by tabs
     # Ignore lines without a number in second column

--- a/resolwe_bio/tools/gff3_to_gtf.py
+++ b/resolwe_bio/tools/gff3_to_gtf.py
@@ -43,5 +43,6 @@ def main():
 
                 f.write(gtf)
 
+
 if __name__ == "__main__":
     main()

--- a/resolwe_bio/tools/go_genesets.py
+++ b/resolwe_bio/tools/go_genesets.py
@@ -51,5 +51,6 @@ def main():
 
     print('{{"num_genesets":{}}}'.format(len(terms)))
 
+
 if __name__ == "__main__":
     main()

--- a/resolwe_bio/tools/importETC.py
+++ b/resolwe_bio/tools/importETC.py
@@ -37,6 +37,8 @@ def import_table(file_name):
         for x in my_reader:
             genes[str(x[0])] = x[1:]
     return times, genes
+
+
 if file_name[-4:] == ".xls" or file_name[-5:] == ".xlsx":
     times, genes = import_excel(file_name)
 

--- a/resolwe_bio/tools/summarize_expression_ncRNA.py
+++ b/resolwe_bio/tools/summarize_expression_ncRNA.py
@@ -31,8 +31,8 @@ args = parser.parse_args()
 
 gene_id_re = re.compile(r'ID=([\w\-\.]*)')
 gene_name_re = re.compile(r'oId=([\w\-\.]*)')
-class_code_re = re.compile(r'class_code=([\w\-\.]*)')
 parent_id_re = re.compile(r'Parent=([\w\-\.]*)')
+class_code_re = re.compile(r'class_code=([\w\-\.]*)')
 
 
 def _search(regex, string):

--- a/resolwe_bio/tools/xexpression.py
+++ b/resolwe_bio/tools/xexpression.py
@@ -133,6 +133,7 @@ def gene_expression_overlap_stranded(gtf_file, bam_file, quality=30):
 
     return genes_exp
 
+
 print("Expression profile overlap...")
 if args.stranded:
     results = gene_expression_overlap_stranded(gtf_file, bam_file)

--- a/resolwe_bio/tools/xgtf2gff.py
+++ b/resolwe_bio/tools/xgtf2gff.py
@@ -35,6 +35,7 @@ def gtf2gff(infileName, outfileName, program):
             else:
                 outfile.write("\t".join(words) + '\n')
 
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument('-p', '--program', help='The name of the program which generated the GTF file.', required=True)

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 # code is written to work on both Python 2 and Python 3
 universal = 1
 
-[pep8]
+[pycodestyle]
 # Django coding style guidelines allow up to 119 characters
 max-line-length = 119
 # Ignore E127: checked by pylint

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
         'test': [
             'check-manifest',
             'coverage>=4.2',
-            'pycodestyle>=2.0.0',
+            'pycodestyle>=2.1.0',
             'pydocstyle>=1.0.0',
             'pylint>=1.6.4',
             'readme_renderer',


### PR DESCRIPTION
Tests are failing with:

    ************* Module resolwe_bio.kb.models
    C: 63, 4: Old-style class defined. (old-style-class)
    ************* Module resolwe_bio.kb.serializers
    C: 18, 4: Old-style class defined. (old-style-class)

@tjanez, @kostko do you have any idea why? Exact same definition for Meta class is passing on Resolwe. Is it possible that linters are run on python 2.7 here and on 3.5 on Resolwe (classes with no parent specified are old-style objects in py2 and new-style objects in py3)?