### PR TITLE
Set Docker Compose's project name to 'resolwebio' to avoid name clashes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ sftp-config.json
 # Ignore dot files
 .*
 !.travis.yml
+!.env
 
 # Ignore backup files
 *.orig

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,6 +6,7 @@ recursive-include docs *.py *.rst *.css *.html
 # include tests and files needed by tests (except large files)
 include tox.ini
 include .pylintrc
+include tests/.env
 recursive-include tests *.py *.yml *.yaml *.rst
 recursive-include resolwe_bio/tests *.py
 recursive-include resolwe_bio/kb/tests *.py

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -25,6 +25,7 @@ Changed
 * Update processes trimmomatic, gff_to_gtf and featureCount
 * Add stitch parameter to rose2 processor
 * Add filtering to DESeq2
+* Set Docker Compose's project name to ``resolwebio`` to avoid name clashes
 
 Added
 -----

--- a/tests/.env
+++ b/tests/.env
@@ -1,0 +1,9 @@
+# Default values of environment variables for Docker Compose
+#
+# NOTE: Values present in the environment at runtime will always override
+# values inside this file. Similarly, values passed via command-line arguments
+# take precedence as well.
+#
+# For more information, see: https://docs.docker.com/compose/env-file/
+# 
+COMPOSE_PROJECT_NAME=resolwebio

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -3,7 +3,6 @@
 #
 postgresql:
     image: postgres:9.4
-    container_name: resolwebio_postgresql
     environment:
         POSTGRES_USER: resolwe
         POSTGRES_DB: resolwe-bio


### PR DESCRIPTION
By default, project name equals the directory name, where `docker-compose.yml` resides.
Since directory name is `tests`, this is prone to clashes with other projects, so we manually set it to `resolwebio`.