### PR TITLE
Document when '--process-dependency-links' has to be used

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -91,7 +91,7 @@ From source
 
 .. code::
 
-   pip install https://github.com/genialis/resolwe-bio/archive/<git-tree-ish>.tar.gz
+   pip install --process-dependecy-links https://github.com/genialis/resolwe-bio/archive/<git-tree-ish>.tar.gz
 
 where ``<git-tree-ish>`` can represent any commit SHA, branch name, tag name,
 etc. in `Resolwe Bioinformatics' GitHub repository`_. For example, to install
@@ -99,7 +99,7 @@ the latest Resolwe Bioinformatics from the ``master`` branch, use:
 
 .. code::
 
-   pip install https://github.com/genialis/resolwe-bio/archive/master.tar.gz
+   pip install --process-dependency-links https://github.com/genialis/resolwe-bio/archive/master.tar.gz
 
 .. _`Resolwe Bioinformatics' GitHub repository`: https://github.com/genialis/resolwe-bio/
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -59,7 +59,7 @@ change directory::
 
 Prepare Resolwe Bioinformatics for development::
 
-    pip install -e .[docs,package,test]
+    pip install --process-dependency-links -e .[docs,package,test]
 
 .. note::
 

--- a/setup.py
+++ b/setup.py
@@ -44,12 +44,12 @@ setup(
     },
     zip_safe=False,
     dependency_links=(
-        "git+https://github.com/genialis/resolwe.git@master#egg=resolwe-1.3.99",
+        "git+https://github.com/genialis/resolwe.git@master#egg=resolwe-master",
     ),
     install_requires=(
         'Django~=1.9.11',
         'djangorestframework>=3.4.0',
-        'resolwe>=1.3.1',
+        'resolwe==master',
         'django-haystack==2.5.0',
         'drf-haystack==1.5.6',
         'Whoosh==2.7.4',


### PR DESCRIPTION
When installing from source or preparing a contributor development environment, use `--process-dependency-links` pip argument to be able to install the latest `master` version of Resolwe from git.
Specify an exact version of Resolwe (during development phase of Resolwe Bioinformatics) and change it to `master` so that it will be always installed from git.