### PR TITLE
Fix parse_diffexp.py to handle adjusted p-vlaue and p-value when 0

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -78,6 +78,7 @@ Fixed
 * Order data objects in ``SampleViewSet``
 * Fix sample hiererhical clustering
 * Fix name in gff to gtf process
+* Fix parse_diffexp.py to handle adjusted p-value or p-value when 0
 
 
 ================

--- a/resolwe_bio/tools/parse_diffexp.py
+++ b/resolwe_bio/tools/parse_diffexp.py
@@ -74,6 +74,14 @@ def main():
 
     outdf = pd.DataFrame(columns)
     outdf = outdf[col_order]
+
+    # replace 0 with lowest adjusted p-value
+    min_p_adjust = min(i for i in outdf['fdr'] if i > 0)
+    outdf['fdr'] = outdf.fdr.mask(outdf.fdr == 0, min_p_adjust)
+    # replace 0 with lowest p-value
+    min_p = min(i for i in outdf['pvalue'] if i > 0)
+    outdf['pvalue'] = outdf.pvalue.mask(outdf.pvalue == 0, min_p)
+
     outdf.to_csv(args.output_file, sep='\t', index=False, compression='gzip')
 
 


### PR DESCRIPTION
This needs to be handled on frontend when is -10log transformation on volcano plot. So this PR is not ok.