### PR TITLE
Use Resolwe's new 'FLOW_DOCKER_COMMAND' setting in test project

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -17,6 +17,7 @@ Fixed
 Changed
 -------
 * Support Resolwe test framework
+* Use Resolwe's new ``FLOW_DOCKER_COMMAND`` setting in test project
 
 
 ================

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -95,8 +95,8 @@ FLOW_EXECUTOR = {
     'UPLOAD_DIR': os.path.join(PROJECT_ROOT, 'test_upload'),
 }
 # Set custom executor command if set via environment variable
-if 'RESOLWE_EXECUTOR_COMMAND' in os.environ:
-    FLOW_EXECUTOR['COMMAND'] = os.environ['RESOLWE_EXECUTOR_COMMAND']
+if 'RESOLWE_DOCKER_COMMAND' in os.environ:
+    FLOW_DOCKER_COMMAND = os.environ['RESOLWE_DOCKER_COMMAND']
 FLOW_API = {
     'PERMISSIONS': 'resolwe.permissions.permissions',
 }


### PR DESCRIPTION
Change test project's settings to allow setting a custom command for the
Docker executor via 'RESOLWE_DOCKER_COMMAND' environment variable.