### PR TITLE
Make tests use the live Resolwe API host instead of external server

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -43,6 +43,7 @@ Changed
   of the docker image should also have their python scripts updated to Python 3.
 * Use ``resolwebio/dnaseq`` docker image in ``align-bwa-trim`` process
 * Refactor ``resolwebio/chipseq`` docker image
+* Make tests use the live Resolwe API host instead of external server
 
 Fixed
 -----

--- a/resolwe_bio/tests/processes/test_enrichment.py
+++ b/resolwe_bio/tests/processes/test_enrichment.py
@@ -1,10 +1,11 @@
 # pylint: disable=missing-docstring
 from resolwe.test import tag_process
-from resolwe_bio.utils.test import KBBioProcessTestCase
+from resolwe_bio.utils.test import with_resolwe_host, KBBioProcessTestCase
 
 
 class EnrichmentProcessorTestCase(KBBioProcessTestCase):
 
+    @with_resolwe_host
     @tag_process('goenrichment')
     def test_go_enrichment_dicty(self):
         with self.preparation_stage():
@@ -25,6 +26,7 @@ class EnrichmentProcessorTestCase(KBBioProcessTestCase):
         self.assertEqual(len(enrichment.process_warning), 0)
         self.assertJSON(enrichment, enrichment.output['terms'], '', 'go_enriched_terms_dicty.json.gz')
 
+    @with_resolwe_host
     @tag_process('goenrichment')
     def test_go_enrichment(self):
         with self.preparation_stage():

--- a/resolwe_bio/utils/test.py
+++ b/resolwe_bio/utils/test.py
@@ -7,6 +7,7 @@ import wrapt
 
 from django.conf import settings
 from django.core.management import call_command
+from django.test import LiveServerTestCase
 
 from resolwe.test import with_resolwe_host as resolwe_with_resolwe_host, ProcessTestCase
 
@@ -132,11 +133,19 @@ class BioProcessTestCase(ProcessTestCase):
         return self.run_process('upload-master-file', {'src': mfile, 'panel_name': pname})
 
 
-class KBBioProcessTestCase(BioProcessTestCase):
-    """Test class for bioinformatics processes that uses knowledge base."""
+class KBBioProcessTestCase(BioProcessTestCase, LiveServerTestCase):
+    """Class for bioinformatics process tests that use knowledge base.
 
-    def setUp(self):
+    It is based on :class:`~.BioProcessTestCase` and Django's
+    :class:`~django.test.LiveServerTestCase`.
+    The latter launches a live Django server in a separate thread so
+    that the tests may use it to query the knowledge base.
+
+    """
+
+    @classmethod
+    def setUpClass(cls):
         """Set-up test gene information knowledge base."""
-        super(KBBioProcessTestCase, self).setUp()
+        super(KBBioProcessTestCase, cls).setUpClass()
         call_command('insert_features', os.path.join(TEST_FILES_DIR, 'features_gsea.tab.zip'))
         call_command('insert_mappings', os.path.join(TEST_FILES_DIR, 'mappings_gsea.tab.zip'))


### PR DESCRIPTION
Requires genialis/resolwe#220.

@jkokosar, could you take a look why the `test_go_enrichment` test returns different values for `pval` and `score` which cause the test to fail?

Here is the diff:
```
$ diff obtained-result.json result-from-file.json 
75,76c75,76
<                                                 "pval": 0.5333333333333332,
<                                                 "score": 0.75,
---
>                                                 "pval": 0.6666666666666671,
>                                                 "score": 1.5,
86,87c86,87
<                                         "pval": 0.5333333333333332,
<                                         "score": 0.75,
---
>                                         "pval": 0.6666666666666671,
>                                         "score": 1.5,
97,98c97,98
<                                 "pval": 0.5333333333333332,
<                                 "score": 0.75,
---
>                                 "pval": 0.6666666666666671,
>                                 "score": 1.5,
108,109c108,109
<                         "pval": 0.5333333333333332,
<                         "score": 0.75,
---
>                         "pval": 0.6666666666666671,
>                         "score": 1.5,
124,125c124,125
<                                         "pval": 0.5333333333333332,
<                                         "score": 0.75,
---
>                                         "pval": 0.6666666666666671,
>                                         "score": 1.5,
135,136c135,136
<                                 "pval": 0.39999999999999963,
<                                 "score": 0.5,
---
>                                 "pval": 1.0,
>                                 "score": 1.0,
146,147c146,147
<                         "pval": 0.39999999999999963,
<                         "score": 0.5,
---
>                         "pval": 1.0,
>                         "score": 1.0,
157,158c157,158
<                 "pval": 0.39999999999999963,
<                 "score": 0.5,
---
>                 "pval": 1.0,
>                 "score": 1.0,
171,172c171,172
<                         "pval": 0.5333333333333332,
<                         "score": 0.75,
---
>                         "pval": 0.6666666666666671,
>                         "score": 1.5,
182,183c182,183
<                 "pval": 0.5333333333333332,
<                 "score": 0.75,
---
>                 "pval": 0.6666666666666671,
>                 "score": 1.5,
```