### PR TITLE
Set correct resource limits based on tests

### DIFF
--- a/resolwe_bio/processes/go_enrichment/go.yml
+++ b/resolwe_bio/processes/go_enrichment/go.yml
@@ -7,6 +7,8 @@
   name: GO Enrichment analysis
   requirements:
     expression-engine: jinja
+    resources:
+      network: true
   data_name: 'GO Enrichment analysis for {{genes|join(", ")|default("?")}}'
   version: 3.0.1
   type: data:goea

--- a/resolwe_bio/processes/icount/annotation.yml
+++ b/resolwe_bio/processes/icount/annotation.yml
@@ -10,6 +10,8 @@
     executor:
       docker:
         image: "resolwe/bio-linux8-resolwe-preview:icount"
+    resources:
+      network: true
   data_name: 'ENSEMBL annotation ({{ species ~ "." ~ release | default("?")}})'
   persistence: RAW
   input:

--- a/resolwe_bio/processes/icount/genome.yml
+++ b/resolwe_bio/processes/icount/genome.yml
@@ -10,6 +10,8 @@
     executor:
       docker:
         image: "resolwe/bio-linux8-resolwe-preview:icount"
+    resources:
+      network: true
   data_name: 'ENSEMBL genome ({{ species ~ "." ~ release | default("?")}})'
   persistence: RAW
   input:

--- a/resolwe_bio/processes/variant_calling/snpeff.yml
+++ b/resolwe_bio/processes/variant_calling/snpeff.yml
@@ -7,6 +7,8 @@
   name: snpEff
   requirements:
     expression-engine: jinja
+    resources:
+      memory: 16384
   data_name: "snpEff ({{ variants|sample_name|default('?') }})"
   version: 0.1.1
   type: data:snpeff


### PR DESCRIPTION
Requires genialis/resolwe#293

Note that these are the minimal limits to make the process unit tests pass. In practice some additional resources may be required for other processes or existing resources need to be changed.