### PR TITLE
WIP: Add test for RNA-seq pipeline

### DIFF
--- a/resolwe_bio/descriptors/rnaseq.yml
+++ b/resolwe_bio/descriptors/rnaseq.yml
@@ -1,0 +1,55 @@
+- slug: rna-seq
+  name: RNA-Seq
+  version: 0.0.1
+  description: RNA-Seq template
+  schema:
+    - name: genome_and_annotation
+      label: Organism
+      type: basic:string
+      default: hs
+      choices:
+        - label: Homo sapiens
+          value: hs
+        - label: Mus musculus
+          value: mm
+    - name: adapters
+      label: Adapters
+      type: basic:string
+      default: 'yes'
+      choices:
+        - label: Remove
+          value: 'yes'
+        - label: Do not remove
+          value: 'no'
+    - name: minlen
+      label: Minimum read length
+      type: basic:integer
+      default: 10
+      description: >
+        Trimmed reads shorter than the minimum read length will be discarded.
+    - name: trailing
+      label: Trailing quality
+      type: basic:integer
+      default: 28
+      description: >
+        The minimum quality required to keep a base. Bases with lower quality
+        will be removed from the end of reads.
+    - name: stranded
+      label: Assay type
+      type: basic:string
+      default: 'no'
+      choices:
+        - label: Strand non-specific
+          value: 'no'
+        - label: Strand-specific forward
+          value: 'yes'
+        - label: Strand-specific reverse
+          value: reverse
+      description: >
+        In strand non-specific assay a read is considered overlapping with a
+        feature regardless of whether it is mapped to the same or the opposite
+        strand as the feature. In strand-specific forward assay and single
+        reads, the read has to be mapped to the same strand as the feature.
+        For paired-end reads, the first read has to be on the same strand and
+        the second read on the opposite strand. In strand-specific reverse
+        assay these rules are reversed.

--- a/resolwe_bio/processes/workflows/rnaseq.yml
+++ b/resolwe_bio/processes/workflows/rnaseq.yml
@@ -229,3 +229,76 @@
           mode: union
           stranded: '{{input.stranded}}'
           id_attribute: '{{input.id_attribute}}'
+
+- slug: dss-rnaseq
+  name: RNA-Seq for biologists
+  requirements:
+    expression-engine: jinja
+    resources:
+      network: true
+  data_name: "Pipeline ({{ reads|sample_name|default('?') }})"
+  version: 0.0.1
+  type: data:dss:rnaseq
+  category: dss
+  persistence: RAW
+  description: >
+    Run RNA-Seq workflow
+  input:
+    - name: reads
+      label: Input reads
+      type: data:reads:fastq
+    - name: genome_and_annotation
+      label: Organism
+      type: basic:string
+      default: hs
+      choices:
+        - label: Homo sapiens
+          value: hs
+        - label: Mus musculus
+          value: mm
+    - name: adapters
+      label: Adapters
+      type: basic:string
+      default: 'yes'
+      choices:
+        - label: Remove
+          value: 'yes'
+        - label: Do not remove
+          value: 'no'
+    - name: minlen
+      label: Minimum read length
+      type: basic:integer
+      default: 10
+      description: >
+        Trimmed reads shorter than the minimum read length will be discarded.
+    - name: trailing
+      label: Trailing quality
+      type: basic:integer
+      default: 28
+      description: >
+        The minimum quality required to keep a base. Bases with lower quality
+        will be removed from the end of reads.
+    - name: stranded
+      label: Assay type
+      type: basic:string
+      default: 'no'
+      choices:
+        - label: Strand non-specific
+          value: 'no'
+        - label: Strand-specific forward
+          value: 'yes'
+        - label: Strand-specific reverse
+          value: reverse
+      description: >
+        In strand non-specific assay a read is considered overlapping with a
+        feature regardless of whether it is mapped to the same or the opposite
+        strand as the feature. In strand-specific forward assay and single
+        reads, the read has to be mapped to the same strand as the feature.
+        For paired-end reads, the first read has to be on the same strand and
+        the second read on the opposite strand. In strand-specific reverse
+        assay these rules are reversed.
+  run:
+    runtime: polyglot
+    language: bash
+    program: |
+      rnaseq.py "{{reads|type}}" "{{reads|id}}" "{{genome_and_annotation}}" "{{adapters}}" "{{minlen}}" "{{trailing}}" "{{stranded}}"

--- a/resolwe_bio/tests/workflows/test_rna_seq.py
+++ b/resolwe_bio/tests/workflows/test_rna_seq.py
@@ -115,3 +115,34 @@ class RNASeqWorkflowTestCase(BioProcessTestCase):
         self.assertFile(workflow, 'rc', 'workflow_rnaseq_paired_rc.tab.gz', compression='gzip')
         self.assertFields(workflow, 'exp_type', 'TPM')
         self.assertFields(workflow, 'source', 'DICTYBASE')
+
+
+class RNASeqDSSTestCase(BioProcessTestCase):
+    def test_dss_rnaseq(self):
+        genome = self.prepare_genome()
+        genome.slug = 'genome-mm10'
+        single_reads = self.prepare_reads()
+        paired_reads = self.prepare_paired_reads()
+        annotation = self.prepare_annotation('annotation.gtf.gz')
+        annotation.slug = 'annotation-mm10'
+        adapters = self.prepare_adapters()
+        adapters.slug = 'adapters-illumina'
+
+        self.run_process('dss-rnaseq', {
+            'genome_and_annotation': 'mm',
+            'reads': single_reads.id
+        })
+        workflow = Data.objects.last()
+        self.assertFile(workflow, 'rc', 'workflow_rnaseq_single_rc.tab.gz', compression='gzip')
+        self.assertFields(workflow, 'exp_type', 'TPM')
+        self.assertFields(workflow, 'source', 'DICTYBASE')
+
+        self.run_process('dss-rnaseq', {
+            'genome_and_annotation': 'mm',
+            'reads': paired_reads.id,
+            'trailing': 1
+        })
+        workflow = Data.objects.last()
+        self.assertFile(workflow, 'rc', 'workflow_rnaseq_paired_rc.tab.gz', compression='gzip')
+        self.assertFields(workflow, 'exp_type', 'TPM')
+        self.assertFields(workflow, 'source', 'DICTYBASE')

--- a/resolwe_bio/tools/rnaseq.py
+++ b/resolwe_bio/tools/rnaseq.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+
+"""RNA-Seq for biologists."""
+
+from argparse import ArgumentParser
+from json import dumps
+from sys import exit
+from resdk import Resolwe
+
+GENOMES_AND_ANNOTATIONS = {
+    'hs': ('genome-hg19', 'annotation-hg19'),
+    'mm': ('genome-mm10', 'annotation-mm10')
+}
+ADAPTERS = {
+    'yes': 'adapters-illumina',
+    'no': None
+}
+
+
+def parse_arguments():
+    """Parse command line arguments."""
+    parser = ArgumentParser(description='Run RNA-Seq for biologists')
+    parser.add_argument('type', help='Reads data type')
+    parser.add_argument('reads', help='Reads')
+    parser.add_argument('genome_and_annotation', help='Genome and annotation')
+    parser.add_argument('adapters', help='Adapters')
+    parser.add_argument('minlen', type=int, help='Min length')
+    parser.add_argument('trailing', type=int, help='Trailing quality')
+    parser.add_argument('stranded', help='Stranded')
+    return parser.parse_args()
+
+
+def get_data_id(res, slug, type=None):
+    """Throw an error if data object is missing."""
+    data_objs = res.data.filter(slug=slug, type=type)
+    if not data_objs:
+        print("Server configuration error: no slug '{}' with type '{}'.".format(slug, type))
+        exit()
+    return data_objs[0].id
+
+
+def main():
+    """Run RNA-Seq workflow."""
+    args = parse_arguments()
+    data = {
+        'input': {
+            'reads': args.reads,
+            'minlen': args.minlen,
+            'trailing': args.trailing,
+            'stranded': args.stranded
+        }
+    }
+    if args.type.startswith('data:reads:fastq:single:'):
+        data['process'] = 'workflow-rnaseq-single'
+    if args.type.startswith('data:reads:fastq:paired:'):
+        data['process'] = 'workflow-rnaseq-paired'
+
+    gna = GENOMES_AND_ANNOTATIONS[args.genome_and_annotation]
+    ada = ADAPTERS[args.adapters]
+    res = Resolwe()
+    data['input']['genome'] = get_data_id(res, gna[0], 'data:genome:fasta:')
+    data['input']['annotation'] = get_data_id(res, gna[1], 'data:annotation:gtf:')
+    data['input']['adapters'] = get_data_id(res, ada, 'data:seq:nucleotide:')
+    print('run {}'.format(dumps(data, separators=(',', ':'))))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
The newly introduced `workflow_meta_rnaseq` has the same inputs as `workflow-rnaseq-paired` which is already present in the master branch. In the case where single reads are provided as an input to the meta-process, `palindrome_clip_threshold` is disregarded in `rnaseq.py` and can be set to hidden in the YAML file of the meta-process when this feature is available (see [https://github.com/genialis/genialis-apps/issues/589](https://github.com/genialis/genialis-apps/issues/589)). The included descriptor schema can be used with `workflow-rnaseq-single`, `workflow-rnaseq-paired`, and `workflow_meta_rnaseq`.