### PR TITLE
Remove coverage report from tests

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,7 +5,6 @@ include README.rst
 recursive-include docs *.py *.rst *.css *.html
 # include tests and files needed by tests (except large files)
 include tox.ini
-include .coveragerc
 include .pylintrc
 include tests/.env
 recursive-include tests *.py *.yml *.yaml *.rst

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,6 @@ setup(
         ],
         'test': [
             'check-manifest',
-            'coverage>=4.2',
             # pycodestyle 2.3.0 raises false-positive for variables
             # starting with 'def'
             # https://github.com/PyCQA/pycodestyle/issues/617

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ commands =
          print(settings.FLOW_EXECUTOR[\"CONTAINER_IMAGE\"])" \
     )\'
 # run tests
-    coverage run tests/manage.py test {env:TEST_SUITE:resolwe_bio} --noinput \
+    python tests/manage.py test {env:TEST_SUITE:resolwe_bio} --noinput \
         --verbosity 2 --parallel
 whitelist_externals = bash
 setenv =


### PR DESCRIPTION
Coverage is no longer used and is even not configured, so it is ok to
remove it.