### PR TITLE
Fix gene source check in hierarchical clustering and PCA

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -23,6 +23,7 @@ Fixed
 * Fix NaN in explained variance in PCA. When PC1 alone explained more
   than 99% of variance, explained variance for PC2 was not returned.
 * Fix input sanitization error in ``dss-rna-seq``
+* Fix gene source check in hierarchical clustering and PCA.
 
 
 ================

--- a/resolwe_bio/processes/clustering/hierarchical_clustering.yml
+++ b/resolwe_bio/processes/clustering/hierarchical_clustering.yml
@@ -74,7 +74,7 @@
   requirements:
     expression-engine: jinja
   data_name: 'Hierarchical clustering of samples'
-  version: 1.0.10
+  version: 1.0.11
   type: data:clustering:hierarchical:sample
   category: analyses
   persistence: TEMP
@@ -91,6 +91,7 @@
       placeholder: new gene id
     - name: genes_source
       label: Source of selected genes
+      description: This field is required if gene subset is set.
       type: basic:string
       required: false
     - name: distance
@@ -129,14 +130,17 @@
     runtime: polyglot
     language: bash
     program: |
-
-      {% if not genes %}
-        {% for e in exps %}
-          {% if e.source != genes_source %}
-            re-error "Source of selected genes should be the same as the source of all expression files."
+      {% for e in exps %}
+        {% if genes %}
+          {%if e.source != genes_source %}
+            re-error "Source of selected genes must be the same as the source of all expression files."
           {% endif %}
-        {% endfor %}
-      {% endif %}
+        {% else %}
+          {% if e.source != exps.0.source %}
+            re-error "All expressions must have the same source."
+          {% endif %}
+        {% endif %}
+      {% endfor %}
 
       samplehcluster.py \
         {% for e in exps %}{{e.exp.file}} {% endfor %} \
@@ -155,7 +159,7 @@
   requirements:
     expression-engine: jinja
   data_name: 'Hierarchical clustering of genes'
-  version: 1.0.5
+  version: 1.0.6
   type: data:clustering:hierarchical:gene
   category: analyses
   persistence: TEMP
@@ -172,6 +176,7 @@
       placeholder: new gene id
     - name: genes_source
       label: Source of selected genes
+      description: This field is required if gene subset is set.
       type: basic:string
       required: false
     - name: distance
@@ -210,13 +215,17 @@
     runtime: polyglot
     language: bash
     program: |
-      {% if not genes %}
-        {% for e in exps %}
-          {% if e.source != genes_source %}
-            re-error "Source of selected genes should be the same as the source of all expression files."
+      {% for e in exps %}
+        {% if genes %}
+          {%if e.source != genes_source %}
+            re-error "Source of selected genes must be the same as the source of all expression files."
           {% endif %}
-        {% endfor %}
-      {% endif %}
+        {% else %}
+          {% if e.source != exps.0.source %}
+            re-error "All expressions must have the same source."
+          {% endif %}
+        {% endif %}
+      {% endfor %}
 
       genehcluster.py \
         {% for e in exps %}{{e.exp.file}} {% endfor %} \

--- a/resolwe_bio/processes/clustering/pca.yml
+++ b/resolwe_bio/processes/clustering/pca.yml
@@ -8,7 +8,7 @@
   requirements:
     expression-engine: jinja
   data_name: 'PCA'
-  version: 1.1.3
+  version: 1.1.4
   type: data:pca
   category: analyses
   persistence: TEMP
@@ -20,8 +20,13 @@
       label: Expressions
       type: list:data:expression
     - name: genes
-      label: Filter genes
+      label: Gene subset
       type: list:basic:string
+      required: false
+    - name: genes_source
+      label: Source of selected genes
+      description: This field is required if gene subset is set.
+      type: basic:string
       required: false
     - name: filter
       label: Exclude genes with low expression
@@ -37,11 +42,18 @@
     runtime: polyglot
     language: bash
     program: |
-      EXPSET_TYPE={{exps.0.exp_type}}
-
       {% for e in exps %}
-        {% if exps.0.exp_type != e.exp_type %}
-          re-save proc.error "Expressions must be of the same expression type"
+        {% if e.exp_type != exps.0.exp_type %}
+          re-error "All expressions must be of the same expression type."
+        {% endif %}
+        {% if genes %}
+          {%if e.source != genes_source %}
+            re-error "Source of selected genes must be the same as the source of all expression files."
+          {% endif %}
+        {% else %}
+          {% if e.source != exps.0.source %}
+            re-error "All expressions must have the same source."
+          {% endif %}
         {% endif %}
       {% endfor %}
 

--- a/resolwe_bio/tests/processes/test_clustering.py
+++ b/resolwe_bio/tests/processes/test_clustering.py
@@ -6,9 +6,9 @@ class ClusteringProcessorTestCase(BioProcessTestCase):
 
     def test_hc_clustering(self):
         """Cannot use assertJSON - JSON output contains ETC object IDs."""
-        expression_1 = self.prepare_expression(f_rc='exp_1_rc.tab.gz', f_exp='exp_1_tpm.tab.gz', f_type="TPM")
-        expression_2 = self.prepare_expression(f_rc='exp_2_rc.tab.gz', f_exp='exp_2_tpm.tab.gz', f_type="TPM")
-        expression_3 = self.prepare_expression(f_rc='exp_2_rc.tab.gz', f_exp='exp_2_tpm.tab.gz', f_type="TPM")
+        expression_1 = self.prepare_expression(f_rc='exp_1_rc.tab.gz', f_exp='exp_1_tpm.tab.gz', f_type='TPM')
+        expression_2 = self.prepare_expression(f_rc='exp_2_rc.tab.gz', f_exp='exp_2_tpm.tab.gz', f_type='TPM')
+        expression_3 = self.prepare_expression(f_rc='exp_2_rc.tab.gz', f_exp='exp_2_tpm.tab.gz', f_type='TPM')
 
         inputs = {'expressions': [expression_1.pk, expression_2.pk, expression_3.pk]}
         etc = self.run_process('etc-bcm', inputs)
@@ -19,23 +19,18 @@ class ClusteringProcessorTestCase(BioProcessTestCase):
         self.run_process('clustering-hierarchical-genes-etc', inputs)
 
     def test_hc_clustering_samples_ucsc(self):
-        inputs = {'exp': 'clustering_expressions_1.tab.gz',
-                  'exp_type': 'Log2',
-                  'exp_name': 'Expression',
-                  'source': 'UCSC'}
-        expression_1 = self.run_process('upload-expression', inputs)
-
-        inputs = {'exp': 'clustering_expressions_2.tab.gz',
-                  'exp_type': 'Log2',
-                  'exp_name': 'Expression',
-                  'source': 'UCSC'}
-        expression_2 = self.run_process('upload-expression', inputs)
-
-        inputs = {'exp': 'clustering_expressions_3.tab.gz',
-                  'exp_type': 'Log2',
-                  'exp_name': 'Expression',
-                  'source': 'UCSC'}
-        expression_3 = self.run_process('upload-expression', inputs)
+        expression_1 = self.prepare_expression(f_exp='clustering_expressions_1.tab.gz',
+                                               f_type='Log2',
+                                               name='Expression',
+                                               source='UCSC')
+        expression_2 = self.prepare_expression(f_exp='clustering_expressions_2.tab.gz',
+                                               f_type='Log2',
+                                               name='Expression',
+                                               source='UCSC')
+        expression_3 = self.prepare_expression(f_exp='clustering_expressions_3.tab.gz',
+                                               f_type='Log2',
+                                               name='Expression',
+                                               source='UCSC')
 
         inputs = {'exps': [expression_1.pk, expression_2.pk, expression_3.pk],
                   'genes': ['A1BG', 'E2f4', 'A2ML1', 'A2MP1', 'A3GALT2', 'A4GALT',
@@ -49,23 +44,18 @@ class ClusteringProcessorTestCase(BioProcessTestCase):
         self.assertTrue('order' in test_json)
 
     def test_hc_clustering_genes_ucsc(self):
-        inputs = {'exp': 'clustering_expressions_1.tab.gz',
-                  'exp_type': 'Log2',
-                  'exp_name': 'Expression',
-                  'source': 'UCSC'}
-        expression_1 = self.run_process('upload-expression', inputs)
-
-        inputs = {'exp': 'clustering_expressions_2.tab.gz',
-                  'exp_type': 'Log2',
-                  'exp_name': 'Expression',
-                  'source': 'UCSC'}
-        expression_2 = self.run_process('upload-expression', inputs)
-
-        inputs = {'exp': 'clustering_expressions_3.tab.gz',
-                  'exp_type': 'Log2',
-                  'exp_name': 'Expression',
-                  'source': 'UCSC'}
-        expression_3 = self.run_process('upload-expression', inputs)
+        expression_1 = self.prepare_expression(f_exp='clustering_expressions_1.tab.gz',
+                                               f_type='Log2',
+                                               name='Expression',
+                                               source='UCSC')
+        expression_2 = self.prepare_expression(f_exp='clustering_expressions_2.tab.gz',
+                                               f_type='Log2',
+                                               name='Expression',
+                                               source='UCSC')
+        expression_3 = self.prepare_expression(f_exp='clustering_expressions_3.tab.gz',
+                                               f_type='Log2',
+                                               name='Expression',
+                                               source='UCSC')
 
         inputs = {'exps': [expression_1.pk, expression_2.pk, expression_3.pk],
                   'genes': ['A1BG', 'E2f4', 'A2ML1', 'A2MP1', 'A3GALT2', 'A4GALT',
@@ -79,23 +69,18 @@ class ClusteringProcessorTestCase(BioProcessTestCase):
         self.assertTrue('order' in test_json)
 
     def test_hc_clustering_genes_ncbi(self):
-        inputs = {'exp': 'clustering_NCBI.gz',
-                  'exp_type': 'rc',
-                  'exp_name': 'Expression',
-                  'source': 'NCBI'}
-        expression_1 = self.run_process('upload-expression', inputs)
-
-        inputs = {'exp': 'clustering_NCBI_1.gz',
-                  'exp_type': 'rc',
-                  'exp_name': 'Expression',
-                  'source': 'NCBI'}
-        expression_2 = self.run_process('upload-expression', inputs)
-
-        inputs = {'exp': 'clustering_NCBI_2.gz',
-                  'exp_type': 'rc',
-                  'exp_name': 'Expression',
-                  'source': 'NCBI'}
-        expression_3 = self.run_process('upload-expression', inputs)
+        expression_1 = self.prepare_expression(f_exp='clustering_NCBI.gz',
+                                               f_type='rc',
+                                               name='Expression',
+                                               source='NCBI')
+        expression_2 = self.prepare_expression(f_exp='clustering_NCBI_1.gz',
+                                               f_type='rc',
+                                               name='Expression',
+                                               source='NCBI')
+        expression_3 = self.prepare_expression(f_exp='clustering_NCBI_2.gz',
+                                               f_type='rc',
+                                               name='Expression',
+                                               source='NCBI')
 
         inputs = {'exps': [expression_1.pk, expression_2.pk, expression_3.pk],
                   'genes': ['1', '503538', '56934', '29974', '2', '144571', '3'],
@@ -107,23 +92,18 @@ class ClusteringProcessorTestCase(BioProcessTestCase):
         self.assertTrue('order' in test_json)
 
     def test_hc_clustering_samples_ncbi(self):
-        inputs = {'exp': 'clustering_NCBI.gz',
-                  'exp_type': 'rc',
-                  'exp_name': 'Expression',
-                  'source': 'NCBI'}
-        expression_1 = self.run_process('upload-expression', inputs)
-
-        inputs = {'exp': 'clustering_NCBI_1.gz',
-                  'exp_type': 'rc',
-                  'exp_name': 'Expression',
-                  'source': 'NCBI'}
-        expression_2 = self.run_process('upload-expression', inputs)
-
-        inputs = {'exp': 'clustering_NCBI_2.gz',
-                  'exp_type': 'rc',
-                  'exp_name': 'Expression',
-                  'source': 'NCBI'}
-        expression_3 = self.run_process('upload-expression', inputs)
+        expression_1 = self.prepare_expression(f_exp='clustering_NCBI.gz',
+                                               f_type='rc',
+                                               name='Expression',
+                                               source='NCBI')
+        expression_2 = self.prepare_expression(f_exp='clustering_NCBI_1.gz',
+                                               f_type='rc',
+                                               name='Expression',
+                                               source='NCBI')
+        expression_3 = self.prepare_expression(f_exp='clustering_NCBI_2.gz',
+                                               f_type='rc',
+                                               name='Expression',
+                                               source='NCBI')
 
         inputs = {'exps': [expression_1.pk, expression_2.pk, expression_3.pk],
                   'genes': ['1', '503538', '56934', '29974', '2', '144571', '3'],

--- a/resolwe_bio/tests/processes/test_pca.py
+++ b/resolwe_bio/tests/processes/test_pca.py
@@ -7,10 +7,16 @@ from resolwe_bio.utils.test import BioProcessTestCase
 class PcaProcessorTestCase(BioProcessTestCase):
 
     def test_pca(self):
-        expression_1 = self.prepare_expression(f_rc='exp_1_rc.tab.gz', f_exp='exp_1_tpm.tab.gz', f_type="TPM")
-        expression_2 = self.prepare_expression(f_rc='exp_2_rc.tab.gz', f_exp='exp_2_tpm.tab.gz', f_type="TPM")
+        expression_1 = self.prepare_expression(f_rc='exp_1_rc.tab.gz',
+                                               f_exp='exp_1_tpm.tab.gz',
+                                               f_type='TPM',
+                                               source='DICTYBASE')
+        expression_2 = self.prepare_expression(f_rc='exp_2_rc.tab.gz',
+                                               f_exp='exp_2_tpm.tab.gz',
+                                               f_type='TPM',
+                                               source='DICTYBASE')
 
-        inputs = {'exps': [expression_1.pk, expression_2.pk]}
+        inputs = {'exps': [expression_1.pk, expression_2.pk], 'genes_source': 'DICTYBASE'}
         pca = self.run_process('pca', inputs)
         saved_json, test_json = self.get_json('pca_plot.json.gz', pca.output['pca'])
         self.assertEqual(test_json['flot']['data'], saved_json['flot']['data'])
@@ -19,36 +25,33 @@ class PcaProcessorTestCase(BioProcessTestCase):
 
         inputs = {
             'exps': [expression_1.pk, expression_2.pk],
-            'genes': ['DPU_G0067098', 'DPU_G0067100', 'DPU_G0067104']  # all zero
+            'genes': ['DPU_G0067098', 'DPU_G0067100', 'DPU_G0067104'],  # all zero
+            'genes_source': 'DICTYBASE'
         }
 
         pca = self.run_process('pca', inputs)
         self.assertEqual(
             pca.process_warning[0],
-            "Expressions of all selected genes are 0. Please select different samples or genes."
+            'Expressions of all selected genes are 0. Please select different samples or genes.'
         )
 
     def test_pca_ncbi(self):
-        inputs = {'exp': 'clustering_NCBI.gz',
-                  'exp_type': 'rc',
-                  'exp_name': 'Expression',
-                  'source': 'NCBI'}
-        expression_1 = self.run_process('upload-expression', inputs)
-
-        inputs = {'exp': 'clustering_NCBI_1.gz',
-                  'exp_type': 'rc',
-                  'exp_name': 'Expression',
-                  'source': 'NCBI'}
-        expression_2 = self.run_process('upload-expression', inputs)
-
-        inputs = {'exp': 'clustering_NCBI_2.gz',
-                  'exp_type': 'rc',
-                  'exp_name': 'Expression',
-                  'source': 'NCBI'}
-        expression_3 = self.run_process('upload-expression', inputs)
+        expression_1 = self.prepare_expression(f_exp='clustering_NCBI.gz',
+                                               f_type='rc',
+                                               name='Expression',
+                                               source='NCBI')
+        expression_2 = self.prepare_expression(f_exp='clustering_NCBI_1.gz',
+                                               f_type='rc',
+                                               name='Expression',
+                                               source='NCBI')
+        expression_3 = self.prepare_expression(f_exp='clustering_NCBI_2.gz',
+                                               f_type='rc',
+                                               name='Expression',
+                                               source='NCBI')
 
         inputs = {'exps': [expression_1.pk, expression_2.pk, expression_3.pk, ],
-                  'genes': ["1", "503538", "56934", "29974", "2", "144571", "3", "abc", "lll"]}
+                  'genes': ['1', '503538', '56934', '29974', '2', '144571', '3', 'abc', 'lll'],
+                  'genes_source': 'NCBI'}
         pca = self.run_process('pca', inputs)
         saved_json, test_json = self.get_json('pca_plot_ncbi.json.gz', pca.output['pca'])
         six.assertCountEqual(self, test_json['zero_gene_symbols'], saved_json['zero_gene_symbols'])


### PR DESCRIPTION
Hidden state was not set for `genes_source` input because it did not react to the changes in the content of the `genes` input.