### PR TITLE
Revert "Use git's 'union' merge driver for the CHANGELOG"

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -19,9 +19,5 @@
 
 *.bam binary
 
-# Use git's 'union' merge driver for the CHANGELOG to prevent common merge
-# conflicts when rebasing pull requests.
-docs/CHANGELOG.rst merge=union
-
 # Use Git Large File Storage (LFS) for large test files
 resolwe_bio/tests/files/large/* filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
This reverts commit 4463434a9a3441868caa2395351eedf6fce46a51.

We had many issues with wrongly "merged" CHANGELOGs and people often didn't notice them. Hence, it is better to present developers with the conflicted regions and ask them to manually resolve the them.