### PR TITLE
Add 'FLOW_DOCKER_DONT_PULL' setting

### DIFF
--- a/tests/settings.py
+++ b/tests/settings.py
@@ -5,6 +5,7 @@ Django settings for running tests for Resolwe package.
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
+from distutils.util import strtobool  # pylint: disable=import-error,no-name-in-module
 
 PROJECT_ROOT = os.path.abspath(os.path.dirname(__file__))
 
@@ -127,6 +128,9 @@ FLOW_DOCKER_MAPPINGS = [
      'dest': '/upload',
      'mode': 'rw,z'},
 ]
+
+# Don't pull Docker images if set via the environment variable.
+FLOW_DOCKER_DONT_PULL = strtobool(os.environ.get('RESOLWE_DOCKER_DONT_PULL', '0'))
 
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (


### PR DESCRIPTION
We've recently changed the resolwe 'register' command to
also pull Docker images after process registration is done,
as this prevents using stale or obsolete Docker images in
tests, as well as in production.

In some cases, this might not be desired, so a new setting
was added to prevent pulling images.  This can be useful
during development, since the developer will probably not
want to pull all the images on every test run.

To use this option, simply set the environment variable
'RESOLWE_DOCKER_DONT_PULL' to '1'.