### PR TITLE
Make BioProcessTestCase non-transactional

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -28,6 +28,7 @@ Added
 
 Changed
 -------
+* **BACKWARD INCOMPATIBLE:** Make ``BioProcessTestCase`` non-transactional
 * Enable Chemut workflow and process tests
 * Remove obsolete mongokey escape functionality
 * Report novel splice-site junctions in HISAT2

--- a/resolwe_bio/tests/workflows/test_rna_seq.py
+++ b/resolwe_bio/tests/workflows/test_rna_seq.py
@@ -4,7 +4,7 @@ from django.test import LiveServerTestCase
 
 from guardian.shortcuts import assign_perm
 
-from resolwe_bio.utils.test import BioProcessTestCase, TransactionBioProcessTestCase
+from resolwe_bio.utils.test import BioProcessTestCase
 from resolwe.flow.models import Data
 from resolwe.test.utils import with_resolwe_host
 
@@ -232,7 +232,7 @@ class RNASeqWorkflowTestCase(BioProcessTestCase):
         self.assertFields(workflow, 'source', 'DICTYBASE')
 
 
-class RNASeqDSSTestCase(TransactionBioProcessTestCase, LiveServerTestCase):
+class RNASeqDSSTestCase(BioProcessTestCase, LiveServerTestCase):
     @with_resolwe_host
     def test_rnaseq_dss(self):
         single_reads = self.prepare_reads()

--- a/resolwe_bio/utils/test.py
+++ b/resolwe_bio/utils/test.py
@@ -7,9 +7,8 @@ import wrapt
 
 from django.conf import settings
 from django.core.management import call_command
-from django.test import TestCase as DjangoTestCase
 
-from resolwe.test import with_resolwe_host as resolwe_with_resolwe_host, TransactionProcessTestCase
+from resolwe.test import with_resolwe_host as resolwe_with_resolwe_host, ProcessTestCase
 
 from resolwe_bio.models import Sample
 
@@ -69,21 +68,18 @@ def with_resolwe_host(wrapped_method, instance, args, kwargs):
     )(resolwe_with_resolwe_host)(wrapped_method)(*args, **kwargs)
 
 
-class TransactionBioProcessTestCase(TransactionProcessTestCase):
-    """Base class for writing bioinformatics process tests not enclosed in a transaction.
+class BioProcessTestCase(ProcessTestCase):
+    """Base class for writing bioinformatics process tests.
 
-    It is a subclass of Resolwe's
-    :class:`~resolwe.test.TransactionProcessTestCase` with some specific
-    functions used for testing bioinformatics processes.
-
-    It is useful when one needs access to the process test's database
-    from another thread/process.
+    It is a subclass of Resolwe's :class:`~resolwe.test.ProcessTestCase`
+    with some specific functions used for testing bioinformatics
+    processes.
 
     """
 
     def setUp(self):
         """Initialize test files path."""
-        super(TransactionBioProcessTestCase, self).setUp()
+        super(BioProcessTestCase, self).setUp()
         self.files_path = TEST_FILES_DIR
 
     def prepare_genome(self):
@@ -134,19 +130,6 @@ class TransactionBioProcessTestCase(TransactionProcessTestCase):
     def prepare_amplicon_master_file(self, mfile='56G_masterfile_test.txt', pname='56G panel, v2'):
         """Prepare amplicon master file."""
         return self.run_process('upload-master-file', {'src': mfile, 'panel_name': pname})
-
-
-class BioProcessTestCase(TransactionBioProcessTestCase, DjangoTestCase):
-    """Base class for writing bioinformatics process tests.
-
-    It is based on :class:`~.TransactionBioProcessTestCase` and
-    Django's :class:`~django.test.TestCase`.
-    The latter encloses the test code in a database transaction that is
-    rolled back at the end of the test.
-
-    """
-
-    pass
 
 
 class KBBioProcessTestCase(BioProcessTestCase):


### PR DESCRIPTION
Remove `BioProcessTestCase` that enclosed tests' code in a transaction and rename the non-transactional `TransactionBioProcessTestCase` to `BioProcessTestCase`.