### PR TITLE
Set maximum RAM requirement in 'bbduk' process

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -19,6 +19,7 @@ Changed
 -------
 * **BACKWARD INCOMPATIBLE:** Drop Python 2 support, require Python 3.4 or 3.5
 * **BACKWARD INCOMPATIBLE:** Make species part of the feature primary key
+* Set maximum RAM requirement in ``bbduk`` process
 
 
 ==================

--- a/resolwe_bio/processes/reads_processing/bbduk.yml
+++ b/resolwe_bio/processes/reads_processing/bbduk.yml
@@ -13,7 +13,7 @@
       docker:
         image: resolwebio/legacy:latest
   data_name: '{{ reads.fastq.0.file|default("?") }}'
-  version: 0.0.5
+  version: 0.0.6
   type: data:reads:fastq:single:bbduk
   category: analyses
   flow_collection: sample
@@ -311,7 +311,8 @@
         {% if threads %}threads={{threads}}{% endif %} \
         out=out_reads.fastq \
         stats=stats.txt \
-        statscolumns=5
+        statscolumns=5 \
+        -Xmx1g
 
       re-checkrc "Failed while processing with bbduk.sh"
 
@@ -348,7 +349,7 @@
       docker:
         image: resolwebio/legacy:latest
   data_name: '{{ reads.fastq.0.file|default("?") }}'
-  version: 0.0.5
+  version: 0.0.6
   type: data:reads:fastq:paired:bbduk
   category: analyses
   flow_collection: sample
@@ -662,7 +663,8 @@
         out=fw_paired_filtered.fastq \
         out2=rw_paired_filtered.fastq \
         stats=bbduk_stats.txt \
-        statscolumns=5
+        statscolumns=5 \
+        -Xmx1g
       re-checkrc "Failed while processing with bbduk.sh"
       mv fw_paired_filtered.fastq "${NAME1}_paired_filtered.fastq"
       gzip "${NAME1}_paired_filtered.fastq"


### PR DESCRIPTION
Internal estimation of free RAM by 'bbduk' sometimes returns a negative value if the memory requirement is not explicitly specified.