### PR TITLE
Drop Python 2 support, require Python 3.4 or 3.5

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -17,6 +17,7 @@ Added
 
 Changed
 -------
+* **BACKWARD INCOMPATIBLE:** Drop Python 2 support, require Python 3.4 or 3.5
 * **BACKWARD INCOMPATIBLE:** Make species part of the feature primary key
 
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -5,8 +5,8 @@ Contributing
 Installing prerequisites
 ========================
 
-Make sure you have Python_ (2.7 or 3.4+) installed on your system. If you don't
-have it yet, follow `these instructions
+Make sure you have Python_ (3.4+) installed on your system. If you don't have
+it yet, follow `these instructions
 <https://docs.python.org/3/using/index.html>`__.
 
 Resolwe Bioinformatics requires PostgreSQL_ (9.4+). Many Linux distributions
@@ -63,9 +63,8 @@ Prepare Resolwe Bioinformatics for development::
 
 .. note::
 
-    We recommend using `virtualenv <https://virtualenv.pypa.io/>`_ (on
-    Python 2.7) or `pyvenv <http://docs.python.org/3/library/venv.html>`_ (on
-    Python 3.4+) to create an isolated Python environment for Resolwe.
+    We recommend using `pyvenv <http://docs.python.org/3/library/venv.html>`_
+    to create an isolated Python environment for Resolwe Bioinformatics.
 
 .. _Resolwe Bioinformatics' git repository: https://github.com/genialis/resolwe-bio
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,3 @@
-[bdist_wheel]
-# code is written to work on both Python 2 and Python 3
-universal = 1
-
 [check-manifest]
 # patterns to ignore when checking MANIFEST.in for completness
 ignore =

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
         # have to pin it
         'django-filter~=1.0.0',
     ),
+    python_requires='>=3.4, <3.6',
     extras_require = {
         'docs':  [
             # XXX: Temporarily pin Sphinx to version 1.5.x since 1.6 doesn't work with our custom
@@ -96,8 +97,6 @@ setup(
         'Operating System :: OS Independent',
 
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,34,35},docs,linters,packaging,extra,migrations
+envlist = py{34,35},docs,linters,packaging,extra,migrations
 skip_missing_interpreters = True
 
 [tox:jenkins]
@@ -92,6 +92,8 @@ commands =
     python .scripts/check_large_files.py resolwe_bio/tests/files
 
 [testenv:migrations]
+# we want to always run migrations tests with Python 3
+basepython = python3
 whitelist_externals =
     bash
     psql


### PR DESCRIPTION
Use `python_requires` `setup()` argument to specify the required Python version.