### PR TITLE
Use Pylint 1.8.0+

### DIFF
--- a/resolwe_bio/tests/processes/test_alignment.py
+++ b/resolwe_bio/tests/processes/test_alignment.py
@@ -1,8 +1,9 @@
 # pylint: disable=missing-docstring
-from resolwe_bio.utils.test import BioProcessTestCase
-from resolwe_bio.models import Sample
 from resolwe.flow.models import Data
 from resolwe.test import tag_process
+
+from resolwe_bio.utils.test import BioProcessTestCase
+from resolwe_bio.models import Sample
 
 
 class AlignmentProcessorTestCase(BioProcessTestCase):

--- a/resolwe_bio/tests/processes/test_demultiplex.py
+++ b/resolwe_bio/tests/processes/test_demultiplex.py
@@ -1,7 +1,8 @@
 # pylint: disable=missing-docstring
-from resolwe_bio.utils.test import BioProcessTestCase
 from resolwe.flow.models import Data
 from resolwe.test import tag_process
+
+from resolwe_bio.utils.test import BioProcessTestCase
 
 
 class DemultiplexProcessorTestCase(BioProcessTestCase):

--- a/resolwe_bio/tests/processes/test_support_processors.py
+++ b/resolwe_bio/tests/processes/test_support_processors.py
@@ -1,8 +1,8 @@
 # pylint: disable=missing-docstring
-from resolwe_bio.utils.test import BioProcessTestCase
-
 from resolwe.flow.models import Data
 from resolwe.test import tag_process
+
+from resolwe_bio.utils.test import BioProcessTestCase
 
 
 class SupportProcessorTestCase(BioProcessTestCase):

--- a/resolwe_bio/tests/workflows/test_amplicon.py
+++ b/resolwe_bio/tests/workflows/test_amplicon.py
@@ -1,7 +1,8 @@
 # pylint: disable=missing-docstring
-from resolwe_bio.utils.test import skipDockerFailure, BioProcessTestCase
 from resolwe.flow.models import Data
 from resolwe.test import tag_process
+
+from resolwe_bio.utils.test import skipDockerFailure, BioProcessTestCase
 
 
 class AmpliconWorkflowTestCase(BioProcessTestCase):

--- a/resolwe_bio/tests/workflows/test_chemut.py
+++ b/resolwe_bio/tests/workflows/test_chemut.py
@@ -1,8 +1,9 @@
 # pylint: disable=missing-docstring
-from resolwe_bio.utils.filter import filter_vcf_variable
-from resolwe_bio.utils.test import BioProcessTestCase
 from resolwe.flow.models import Data
 from resolwe.test import tag_process
+
+from resolwe_bio.utils.filter import filter_vcf_variable
+from resolwe_bio.utils.test import BioProcessTestCase
 
 
 class CheMutWorkflowTestCase(BioProcessTestCase):

--- a/resolwe_bio/tests/workflows/test_chip_seq.py
+++ b/resolwe_bio/tests/workflows/test_chip_seq.py
@@ -1,6 +1,7 @@
 # pylint: disable=missing-docstring
-from resolwe_bio.utils.test import BioProcessTestCase
 from resolwe.test import tag_process
+
+from resolwe_bio.utils.test import BioProcessTestCase
 
 
 class ChipSeqWorkflowTestCase(BioProcessTestCase):

--- a/resolwe_bio/tests/workflows/test_heat_seq.py
+++ b/resolwe_bio/tests/workflows/test_heat_seq.py
@@ -1,7 +1,8 @@
 # pylint: disable=missing-docstring
-from resolwe_bio.utils.test import BioProcessTestCase
 from resolwe.flow.models import Data
 from resolwe.test import tag_process
+
+from resolwe_bio.utils.test import BioProcessTestCase
 
 
 class HeatSeqWorkflowTestCase(BioProcessTestCase):

--- a/resolwe_bio/tests/workflows/test_rna_seq.py
+++ b/resolwe_bio/tests/workflows/test_rna_seq.py
@@ -4,9 +4,10 @@ from django.test import LiveServerTestCase
 
 from guardian.shortcuts import assign_perm
 
-from resolwe_bio.utils.test import BioProcessTestCase
 from resolwe.flow.models import Data
 from resolwe.test import with_resolwe_host, tag_process
+
+from resolwe_bio.utils.test import BioProcessTestCase
 
 
 class RNASeqWorkflowTestCase(BioProcessTestCase):

--- a/resolwe_bio/tests/workflows/test_wgbs.py
+++ b/resolwe_bio/tests/workflows/test_wgbs.py
@@ -1,7 +1,8 @@
 # pylint: disable=missing-docstring
-from resolwe_bio.utils.test import BioProcessTestCase
 from resolwe.flow.models import Data
 from resolwe.test import tag_process
+
+from resolwe_bio.utils.test import BioProcessTestCase
 
 
 class WgbsWorkflowTestCase(BioProcessTestCase):

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ setup(
             # https://github.com/PyCQA/pycodestyle/issues/617
             'pycodestyle~=2.2.0',
             'pydocstyle>=1.0.0',
-            'pylint~=1.7.0',
+            'pylint~=1.8.0',
             'readme_renderer',
             'tblib>=1.3.0',
         ],


### PR DESCRIPTION
Fix wrong order of imports in tests.
The upgrade to Pylint 1.8.0+ is necessary to fix the current `master` branch test failures of type:

```
linters runtests: commands[2] | pylint resolwe_bio .scripts/check_large_files.py
************* Module resolwe_bio.utils.test
W: 72, 0: Unused variable '__class__' (unused-variable)
W: 72, 0: Unused variable '__class__' (unused-variable)
W: 72, 0: Unused variable '__class__' (unused-variable)
W: 72, 0: Unused variable '__class__' (unused-variable)
W: 72, 0: Unused variable '__class__' (unused-variable)
W: 72, 0: Unused variable '__class__' (unused-variable)
W: 72, 0: Unused variable '__class__' (unused-variable)
W: 72, 0: Unused variable '__class__' (unused-variable)
W: 72, 0: Unused variable '__class__' (unused-variable)
W:136, 0: Unused variable '__class__' (unused-variable)

... output trimmed ...

```