### PR TITLE
Switch Docker base image from Ubuntu 17.04 to Ubuntu 17.10

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -10,6 +10,17 @@ This project adheres to `Semantic Versioning <http://semver.org/>`_.
 Unreleased
 ==========
 
+Changed
+-------
+
+- **BACKWARD INCOMPATIBLE:** Remove Ubuntu 17.04 base Docker image due to end
+  of lifetime and change all images to use new ubuntu 17.10 image
+
+Added
+-----
+
+- Add Ubuntu 17.10 base Docker image
+
 
 ==================
 6.2.0 - 2018-01-17

--- a/resolwe_bio/docker_images/base/Dockerfile.ubuntu-17.10
+++ b/resolwe_bio/docker_images/base/Dockerfile.ubuntu-17.10
@@ -1,4 +1,4 @@
-FROM docker.io/resolwe/base:ubuntu-17.04
+FROM docker.io/resolwe/base:ubuntu-17.10
 
 MAINTAINER Resolwe Bioinformatics authors https://github.com/genialis/resolwe-bio
 

--- a/resolwe_bio/docker_images/base/README.md
+++ b/resolwe_bio/docker_images/base/README.md
@@ -1,8 +1,9 @@
 # Base Docker images
 
-The `ubuntu-14.04` and `ubuntu-16.04` images are based on
-[`resolwe/base:ubuntu-14.04`](https://hub.docker.com/r/resolwe/base/) and
-[`resolwe/base:ubuntu-16.04`](https://hub.docker.com/r/resolwe/base/),
+The `ubuntu-14.04`, `ubuntu-16.04` and `ubuntu-17.10` images are based on
+[`resolwe/base:ubuntu-14.04`](https://hub.docker.com/r/resolwe/base/),
+[`resolwe/base:ubuntu-16.04`](https://hub.docker.com/r/resolwe/base/) and
+[`resolwe/base:ubuntu-17.10`](https://hub.docker.com/r/resolwe/base/),
 respectively.
 
 These base images should be used for writing any new processes that are

--- a/resolwe_bio/docker_images/dnaseq/Dockerfile
+++ b/resolwe_bio/docker_images/dnaseq/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/resolwebio/base:ubuntu-17.04
+FROM docker.io/resolwebio/base:ubuntu-17.10
 
 MAINTAINER Resolwe Bioinformatics authors https://github.com/genialis/resolwe-bio
 

--- a/resolwe_bio/docker_images/dnaseq/README.md
+++ b/resolwe_bio/docker_images/dnaseq/README.md
@@ -1,6 +1,6 @@
 # Docker image for processes using DNA-Seq tools
 
-It is based on `ubuntu-17.04` version of [`docker.io/resolwebio/base`](
+It is based on `ubuntu-17.10` version of [`docker.io/resolwebio/base`](
 https://hub.docker.com/r/resolwebio/base/) image.
 
 Included bioinformatics tools:

--- a/resolwe_bio/docker_images/rnaseq/Dockerfile
+++ b/resolwe_bio/docker_images/rnaseq/Dockerfile
@@ -1,3 +1,3 @@
-FROM docker.io/resolwebio/base:ubuntu-17.04
+FROM docker.io/resolwebio/base:ubuntu-17.10
 
 MAINTAINER Resolwe Bioinformatics authors https://github.com/genialis/resolwe-bio

--- a/resolwe_bio/docker_images/rnaseq/README.md
+++ b/resolwe_bio/docker_images/rnaseq/README.md
@@ -1,6 +1,6 @@
 # Docker image for RNA-Seq processes
 
-It is based on `ubuntu-17.04` version of [`docker.io/resolwebio/base`](
+It is based on `ubuntu-17.10` version of [`docker.io/resolwebio/base`](
 https://hub.docker.com/r/resolwebio/base/) image.
 
 Included bioinformatics tools:

--- a/resolwe_bio/processes/import_data/pathway_map.yml
+++ b/resolwe_bio/processes/import_data/pathway_map.yml
@@ -4,7 +4,7 @@
     expression-engine: jinja
     executor:
       docker:
-        image: resolwe/base:ubuntu-17.04
+        image: resolwe/base:ubuntu-17.10
     resources:
       network: true
   data_name: Metabolic Pathway


### PR DESCRIPTION
Ubuntu 17.04 reached end of life on 13. 1. 2018, so it is removed from
base images and Ubuntu 17.10 is added instead.