### PR TITLE
Change base Docker image of resolwebio/rnaseq to resolwebio/base:ubuntu-18.04

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -100,6 +100,8 @@ Changed
   ``resolwebio/chipseq`` docker image
 * Make ID attribute labels in ``featureCounts`` more informative
 * Change 'source' to 'gene ID database' in labes and descriptions
+* Change base Docker image of ``resolwebio/rnaseq`` to
+  ``resolwebio/base:ubuntu-18.04``
 
 Fixed
 -----

--- a/resolwe_bio/docker_images/rnaseq/Dockerfile
+++ b/resolwe_bio/docker_images/rnaseq/Dockerfile
@@ -1,3 +1,3 @@
-FROM docker.io/resolwebio/base:ubuntu-17.10
+FROM docker.io/resolwebio/base:ubuntu-18.04
 
 MAINTAINER Resolwe Bioinformatics authors https://github.com/genialis/resolwe-bio

--- a/resolwe_bio/docker_images/rnaseq/README.md
+++ b/resolwe_bio/docker_images/rnaseq/README.md
@@ -1,6 +1,6 @@
 # Docker image for RNA-Seq processes
 
-It is based on `ubuntu-17.10` version of [`docker.io/resolwebio/base`](
+It is based on `ubuntu-18.04` version of [`docker.io/resolwebio/base`](
 https://hub.docker.com/r/resolwebio/base/) image.
 
 Included bioinformatics tools:


### PR DESCRIPTION
After transition to the `resolwebio/base` Docker image Bioconductor packages stopped working. This is fixed by installing system Ubuntu packages of the affected Bioconductor libraries.