### PR TITLE
Fix custom Trimmomatic script in resolwebio/rnaseq Docker image

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -120,6 +120,8 @@ Fixed
 * The chemical mutagenesis workflow was erroneously categorized as
   ``data:workflow:rnaseq:cuffquant`` type. This is switched to
   ``data:workflow:chemut`` type.
+* Fix custom argument passing script for ``Trimmomatic`` in
+  ``resolwebio/rnaseq`` Docker image
 
 
 ==================

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -122,6 +122,8 @@ Fixed
   ``data:workflow:chemut`` type.
 * Fix custom argument passing script for ``Trimmomatic`` in
   ``resolwebio/rnaseq`` Docker image
+* Fix installation errors for ``dexseq-prepare-annotation2`` in
+  ``resolwebio/rnaseq`` Docker image
 
 
 ==================

--- a/resolwe_bio/docker_images/rnaseq/packages-debian-buildreq.txt
+++ b/resolwe_bio/docker_images/rnaseq/packages-debian-buildreq.txt
@@ -1,5 +1,6 @@
 build-essential
 python3-setuptools
+python3-wheel
 
 # Required for some R packages
 gfortran

--- a/resolwe_bio/docker_images/rnaseq/packages-manual/trimmomatic.sh
+++ b/resolwe_bio/docker_images/rnaseq/packages-manual/trimmomatic.sh
@@ -10,12 +10,19 @@ download_and_verify \
     http://www.usadellab.org/cms/uploads/supplementary/Trimmomatic/Trimmomatic-\${version}.zip \
     Trimmomatic-\${version}
 
-cat >trimmomatic.sh <<EOL
+cat <<'EOF' >TrimmomaticSE
 #!/bin/bash
 
-java -jar /opt/usadellab/trimmomatic/trimmomatic-0.36.jar "$@"
-EOL
-chmod +x trimmomatic.sh
+java -jar /opt/usadellab/trimmomatic/trimmomatic-0.36.jar SE "$@"
+EOF
+chmod +x TrimmomaticSE
+
+cat <<'EOF' >TrimmomaticPE
+#!/bin/bash
+
+java -jar /opt/usadellab/trimmomatic/trimmomatic-0.36.jar PE "$@"
+EOF
+chmod +x TrimmomaticPE
 
 add_binary_path \
     usadellab \


### PR DESCRIPTION
Fix passing parameters from the custom script forward to the `Trimmomatic` tool. The `$@` in the custom script were not escaped and didn't survive the script creation process. 

In this PR two custom scripts are created (one for single and one for paired-end reads) to mimic the `trimmomatic` system package in Ubuntu. This allows calling `Trimmomatic` in the same manner as [before](https://github.com/genialis/resolwe-bio/blob/master/resolwe_bio/processes/import_data/seq_reads.yml#L68).