### PR TITLE
Update dnaseq Docker image base to Ubuntu 18.04

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -106,8 +106,8 @@ Changed
   ``resolwebio/chipseq`` docker image
 * Make ID attribute labels in ``featureCounts`` more informative
 * Change 'source' to 'gene ID database' in labes and descriptions
-* Change base Docker image of ``resolwebio/rnaseq`` to
-  ``resolwebio/base:ubuntu-18.04``
+* Change base Docker images of ``resolwebio/rnaseq`` and ``resolwebio/dnaseq``
+  to ``resolwebio/base:ubuntu-18.04``
 * Processor ``archive-samples`` to create different IGV session files for
   ``build`` and ``species``
 * Expose advanced parameters in Chemical Mutagenesis workflow

--- a/resolwe_bio/docker_images/dnaseq/Dockerfile
+++ b/resolwe_bio/docker_images/dnaseq/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/resolwebio/base:ubuntu-17.10
+FROM docker.io/resolwebio/base:ubuntu-18.04
 
 MAINTAINER Resolwe Bioinformatics authors https://github.com/genialis/resolwe-bio
 

--- a/resolwe_bio/docker_images/dnaseq/README.md
+++ b/resolwe_bio/docker_images/dnaseq/README.md
@@ -1,15 +1,15 @@
 # Docker image for processes using DNA-Seq tools
 
-It is based on `ubuntu-17.10` version of [`docker.io/resolwebio/base`](
+It is based on `ubuntu-18.04` version of [`docker.io/resolwebio/base`](
 https://hub.docker.com/r/resolwebio/base/) image.
 
 Included bioinformatics tools:
 ------------------------------
-* bedtools (v2.26.0+dfsg-3)
-* bwa (v0.7.15-3)
+* bedtools (v2.26.0+dfsg-5)
+* bwa (v0.7.17-1)
 * CheMut
-* Picard Tools (v2.8.1+dfsg-2)
+* Picard Tools (v2.8.1+dfsg-3)
 * Primerclip (v171018)
-* Rsamtools (v1.26.2)
-* SAMtools (v1.6)
-* tabix (v1.3.2)
+* Rsamtools (v1.30.0)
+* SAMtools (v1.7)
+* tabix (v1.7-2)

--- a/resolwe_bio/docker_images/dnaseq/packages-manual/samtools.sh
+++ b/resolwe_bio/docker_images/dnaseq/packages-manual/samtools.sh
@@ -5,8 +5,8 @@
 download_and_verify \
     samtools \
     samtools \
-    1.6 \
-    ee5cd2c8d158a5969a6db59195ff90923c662000816cc0c41a190b2964dbe49e \
+    1.7 \
+    e7b09673176aa32937abd80f95f432809e722f141b5342186dfef6a53df64ca1 \
     https://github.com/samtools/samtools/releases/download/\${version}/samtools-\${version}.tar.bz2 \
     samtools-\${version}
 


### PR DESCRIPTION
@jkokosar 
This is necessary because I can't reinstall anything in the (now unsupported) Ubuntu 17.04 image, and Rsamtools doesn't install properly in the 17.10 image. 