### PR TITLE
Ensure Manager channel prefix is valid in test project's settings

### DIFF
--- a/tests/settings.py
+++ b/tests/settings.py
@@ -5,6 +5,7 @@ Django settings for running tests for Resolwe package.
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
+import re
 from distutils.util import strtobool  # pylint: disable=import-error,no-name-in-module
 
 PROJECT_ROOT = os.path.abspath(os.path.dirname(__file__))
@@ -127,6 +128,8 @@ FLOW_EXECUTION_ENGINES = [
 
 # Check if any Manager settings are set via environment variables
 manager_prefix = os.environ.get('RESOLWE_MANAGER_REDIS_PREFIX', 'resolwe-bio.manager')
+# Ensure Manager channel prefix is a valid Django Channels name.
+manager_prefix = re.sub('[^0-9a-zA-Z.-]', '-', manager_prefix)
 FLOW_MANAGER = {
     'NAME': 'resolwe.flow.managers.workload_connectors.local',
     'REDIS_PREFIX': manager_prefix,


### PR DESCRIPTION
Django Channels only allow unicode strings containing only ASCII alphanumerics, hypens or periods for a Channel name.

This will fix Jenkins failure like [this](https://ci.genialis.com/job/genialis-github/job/resolwe-bio/job/stable%252F7.0.x/1/).