### PR TITLE
Improve manual installation of packages in Docker images

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -10,6 +10,11 @@ This project adheres to `Semantic Versioning <http://semver.org/>`_.
 Unreleased
 ==========
 
+Fixed
+-----
+- Fix manual installation of packages in Docker images to handle dots and
+  spaces in file names correctly
+
 
 ==================
 8.1.0 - 2018-04-13

--- a/resolwe_bio/docker_images/base/common.sh
+++ b/resolwe_bio/docker_images/base/common.sh
@@ -8,11 +8,13 @@ download_and_verify() {
     local sha256sum=$4
     # Eval is required so that the url and subdir arguments can contain references
     # to the \${version} variable.
-    local url=$(eval "echo \"$5\"")
-    local subdir=$(eval "echo \"$6\"")
-
-    local filename=$(basename "$url")
-    local extension="${filename#*.}"
+    local url=$(eval echo $5)
+    local subdir=$(eval echo $6)
+    if [[ -n $7 ]]; then
+        local filename=$(eval echo $7)
+    else
+        local filename=$(basename "$url")
+    fi
 
     echo "Downloading '${vendor}/${name}' version '${version}'..."
 
@@ -20,39 +22,52 @@ download_and_verify() {
     cd "/opt/${vendor}"
 
     echo "Fetching '${url}'..."
-    wget --tries=3 --retry-connrefused --timeout=30 --quiet "${url}" --output-document "${name}.${extension}"
+    wget --tries=3 --retry-connrefused --timeout=30 --quiet "${url}" --output-document "${filename}"
 
     echo "Verifying package..."
     set +e
-        echo "${sha256sum} ${name}.${extension}" | sha256sum -c --status -
+        echo "${sha256sum} ${filename}" | sha256sum -c --status -
         local verify_status=$?
     set -e
 
     if (( ${verify_status} )); then
         >&2 echo "ERROR: SHA256 digest mismatch."
-        rm -f "${name}.${extension}"
+        rm -f "${filename}"
         exit 1
     fi
 
     # Unpack.
     echo "Unpacking..."
-    case "$extension" in
-        *.tar*|tar*|*.tgz|tgz)
-            tar -xf "${name}.${extension}" --directory ${name}
+    case "${filename}" in
+        *.tar|tar| \
+        *.tar.bz2|tarbz2| \
+        *.tb2|tb2| \
+        *.tbz|tbz| \
+        *.tbz2|tbz2| \
+        *.tar.gz|targz| \
+        *.tgz|tgz| \
+        *.tar.lz|tarlz| \
+        *.tar.lzma|tarlzma| \
+        *.tlz|tlz| \
+        *.tar.xz|tarxz| \
+        *.txz|txz| \
+        *.tar.Z|tarZ| \
+        *.tZ|tZ)
+            tar -xf "${filename}" --directory "${name}"
             ;;
         *.zip|zip)
-            unzip -q "${name}.${extension}" -d ${name}
+            unzip -q "${filename}" -d "${name}"
             ;;
         *.elf|elf)
             # The .elf extension should be used when downloading raw binaries.
-            mv "${name}.${extension}" "${name}/${name}"
+            mv "${filename}" "${name}/${name}"
             chmod +x "${name}/${name}"
             ;;
         *)
-            mv "${name}.${extension}" "${name}/"
+            mv "${filename}" "${name}/"
     esac
 
-    rm -f "${name}.${extension}"
+    rm -f "${filename}"
     cd "${name}"
 
     if [[ -n ${subdir} ]]; then


### PR DESCRIPTION
The original `download_and_verify()` script handles dotted filenames incorrectly, e.g. https://cdn.pydata.org/bokeh/release/bokeh-0.12.13.min.css is named `assets.12.13.min.css` when downloaded in https://github.com/genialis/resolwe-bio/pull/523. The case where `name` [contains a space](https://github.com/genialis/resolwe-bio/blob/master/resolwe_bio/docker_images/base/common.sh#L44) is also fixed.