### PR TITLE
Pull USCS tools from Google Drive

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -17,8 +17,8 @@ Added
   - ``Bedops (v2.4.32)``
   - ``Tabix (v1.8)``
   - ``python3-pandas``
-  - ``bedGraphToBigWig (kent-v364)``
-  - ``bedToBigBed (kent-v364)``
+  - ``bedGraphToBigWig (kent-v365)``
+  - ``bedToBigBed (kent-v365)``
 - Add to ``resolwebio/rnaseq`` Docker image:
 
   - ``genometools (1.5.9)``
@@ -26,12 +26,11 @@ Added
   - ``jbrowse (v1.12.0)``
 - Support filtering by type on feature API endpoint
 
-
 Changed
 -------
 - **BACKWARD INCOMPATIBLE:** Drop support for Python 3.4 and 3.5
 - **BACKWARD INCOMPATIBLE:** Require Resolwe 10.x
-- Update ``wigToBigWig`` to kent-v364 version  in ``resolwebio/chipseq``
+- Update ``wigToBigWig`` to kent-v365 version  in ``resolwebio/chipseq``
   Docker image
 
 

--- a/resolwe_bio/docker_images/chipseq/packages-manual/bedgraphtobigwig.sh
+++ b/resolwe_bio/docker_images/chipseq/packages-manual/bedgraphtobigwig.sh
@@ -31,9 +31,9 @@
 download_and_verify \
     kent \
     bedGraphToBigWig \
-    kent-v364 \
-    296caadb7e60645cdc689df13f55a8bd07991dd597de75574f929d399d6cbbf7 \
-    http://hgdownload.cse.ucsc.edu/admin/exe/linux.x86_64/bedGraphToBigWig#.elf
+    kent-v365 \
+    6dc7daaf18bd7b14933eb32cbbee559f5cd69d636578caf2b29e13996f9445c1 \
+    https://drive.google.com/uc?id=1GjBuK1JxSHrxWZhHnrTZmMsxwX6xGUWs#.elf
 
 add_binary_path \
     kent \

--- a/resolwe_bio/docker_images/chipseq/packages-manual/bedtobigbed.sh
+++ b/resolwe_bio/docker_images/chipseq/packages-manual/bedtobigbed.sh
@@ -31,9 +31,9 @@
 download_and_verify \
     kent \
     bedToBigBed \
-    kent-v364 \
-    f20ec4f9cb2d740191554a68fefe86610aed998ec1cdc90b6016c3954e825846 \
-    http://hgdownload.cse.ucsc.edu/admin/exe/linux.x86_64/bedToBigBed#.elf
+    kent-v365 \
+    a66027e1a51f803fef6bf234b90d0e4d6deee6027acfe2c0a65712f3157cca5d \
+    https://drive.google.com/uc?id=1N2pUaJuHgCUS4gztTcoybrRWw1m8WNtv#.elf
 
 wget https://raw.githubusercontent.com/ENCODE-DCC/kentUtils/master/src/hg/lib/encode/narrowPeak.as
 

--- a/resolwe_bio/docker_images/chipseq/packages-manual/wigtobigwig.sh
+++ b/resolwe_bio/docker_images/chipseq/packages-manual/wigtobigwig.sh
@@ -30,9 +30,9 @@
 download_and_verify \
     kent \
     wigToBigWig \
-    kent-v364 \
-    e2743e9c15f911e882e8453be8141b7c0b80cf891ff02d96d93d51b1effe24b5 \
-    http://hgdownload.cse.ucsc.edu/admin/exe/linux.x86_64/wigToBigWig#.elf
+    kent-v365 \
+    278a7da9210b1b82c20dbce33c263094cd7f14b20fdc7f5dbe330bf709ddd04e \
+    https://drive.google.com/uc?id=19M6SZmS0xxaKe3srxt01d0FrdaIYWnHe#.elf
 
 add_binary_path \
     kent \


### PR DESCRIPTION
Pull bedGraphToBigWig, bedToBigBed and wigToBigWig from Drive. On the official website version is updated very frequently and the link remains the same (pointing the latest version), but hash is changing.

@JureZmrzlikar @kostko please review