### PR TITLE
Fix bamtobigwig calculation to timeout after defined time

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -10,6 +10,10 @@ This project adheres to `Semantic Versioning <http://semver.org/>`_.
 Unreleased
 ==========
 
+Fixed
+-----
+- Fix ``bamtobigwig.sh`` to timeout the ``bamCoverage`` calculation after
+  defined time
 
 ===================
 10.0.0 - 2018-06-19

--- a/resolwe_bio/processes/alignment/bowtie.yml
+++ b/resolwe_bio/processes/alignment/bowtie.yml
@@ -13,7 +13,7 @@
     resources:
       cores: 10
   data_name: "Alignment ({{ reads.fastq.0.file|basename|default('?') }})"
-  version: 1.3.1
+  version: 1.3.2
   type: data:alignment:bam:bowtie1
   category: analyses:alignment
   flow_collection: sample
@@ -124,6 +124,7 @@
     - name: bigwig
       label: BigWig file
       type: basic:file
+      required: false
     - name: species
       label: Species
       type: basic:string
@@ -278,11 +279,13 @@
       re-save species {{genome.species}}
       re-save build {{genome.build}}
 
-      bamtobigwig.sh "${FW_NAME}_mapped.bam" {{ requirements.resources.cores }} 50
-
       if [ -f "${FW_NAME}_unmapped.bam" ]; then
         re-save-file unmapped "${FW_NAME}_unmapped.fastq.gz"
       fi
+
+      #computation time limit for bamCoverage is 480s per GB
+      bamtobigwig.sh "${FW_NAME}_mapped.bam" {{ requirements.resources.cores }} 50 480
+
 
 - slug: alignment-bowtie2
   name: Bowtie
@@ -295,7 +298,7 @@
       memory: 8192
       cores: 10
   data_name: "Alignment ({{ reads.fastq.0.file|basename|default('?') }})"
-  version: 1.3.1
+  version: 1.3.2
   type: data:alignment:bam:bowtie2
   category: analyses:alignment
   flow_collection: sample
@@ -439,6 +442,7 @@
     - name: bigwig
       label: BigWig file
       type: basic:file
+      required: false
     - name: species
       label: Species
       type: basic:string
@@ -628,4 +632,5 @@
       re-save species {{genome.species}}
       re-save build {{genome.build}}
 
-      bamtobigwig.sh "${FW_NAME}.bam" {{ requirements.resources.cores }} 50
+      #computation time limit for bamCoverage is 480s per GB
+      bamtobigwig.sh "${FW_NAME}.bam" {{ requirements.resources.cores }} 50 480

--- a/resolwe_bio/processes/alignment/bwa.yml
+++ b/resolwe_bio/processes/alignment/bwa.yml
@@ -13,7 +13,7 @@
     resources:
       cores: 10
   data_name: "Alignment ({{ reads|sample_name|default('?') }})"
-  version: 2.1.1
+  version: 2.1.2
   type: data:alignment:bam:bwamem
   category: analyses:alignment
   flow_collection: sample
@@ -115,6 +115,7 @@
     - name: bigwig
       label: BigWig file
       type: basic:file
+      required: false
     - name: species
       label: Species
       type: basic:string
@@ -217,11 +218,13 @@
       re-save species {{genome.species}}
       re-save build {{genome.build}}
 
-      bamtobigwig.sh "${NAME}.bam" {{ requirements.resources.cores }} 50
-
       if [ -f "${NAME}_unmapped.fastq.gz" ]; then
         re-save-file unmapped "${NAME}_unmapped.fastq.gz"
       fi
+
+      #computation time limit for bamCoverage is 480s per GB
+      bamtobigwig.sh "${NAME}.bam" {{ requirements.resources.cores }} 50 480
+
 
 - slug: alignment-bwa-sw
   name: BWA SW
@@ -233,7 +236,7 @@
     resources:
       cores: 10
   data_name: "Alignment ({{ reads.fastq.0.file|basename|default('?') }})"
-  version: 1.2.1
+  version: 1.2.2
   type: data:alignment:bam:bwasw
   category: analyses:alignment
   flow_collection: sample
@@ -281,6 +284,7 @@
     - name: bigwig
       label: BigWig file
       type: basic:file
+      required: false
     - name: species
       label: Species
       type: basic:string
@@ -365,11 +369,12 @@
       re-save species {{genome.species}}
       re-save build {{genome.build}}
 
-      bamtobigwig.sh "${NAME}.bam" {{ requirements.resources.cores }} 50
-
       if [ -f "${NAME}_unmapped.fastq.gz" ]; then
         re-save-file unmapped "${NAME}_unmapped.fastq.gz"
       fi
+
+      #computation time limit for bamCoverage is 480s per GB
+      bamtobigwig.sh "${NAME}.bam" {{ requirements.resources.cores }} 50 480
 
 - slug: alignment-bwa-aln
   name: BWA ALN
@@ -381,7 +386,7 @@
     resources:
       cores: 10
   data_name: "Alignment ({{ reads.fastq.0.file|basename|default('?') }})"
-  version: 1.2.1
+  version: 1.2.2
   type: data:alignment:bam:bwaaln
   category: analyses:alignment
   flow_collection: sample
@@ -443,6 +448,7 @@
     - name: bigwig
       label: BigWig file
       type: basic:file
+      required: false
     - name: species
       label: Species
       type: basic:string
@@ -543,8 +549,9 @@
       re-save species {{genome.species}}
       re-save build {{genome.build}}
 
-      bamtobigwig.sh "${NAME}.bam" {{ requirements.resources.cores }} 50
-
       if [ -f "${NAME}_unmapped.fastq.gz" ]; then
         re-save-file unmapped "${NAME}_unmapped.fastq.gz"
       fi
+
+      #computation time limit for bamCoverage is 480s per GB
+      bamtobigwig.sh "${NAME}.bam" {{ requirements.resources.cores }} 50 480

--- a/resolwe_bio/processes/alignment/hisat2.yml
+++ b/resolwe_bio/processes/alignment/hisat2.yml
@@ -14,7 +14,7 @@
       docker:
         image: resolwebio/rnaseq:3.4.0
   data_name: "Alignment ({{ reads|sample_name|default('?') }})"
-  version: 1.5.1
+  version: 1.5.2
   type: data:alignment:bam:hisat2
   category: analyses:alignment
   flow_collection: sample
@@ -75,6 +75,7 @@
     - name: bigwig
       label: BigWig file
       type: basic:file
+      required: false
     - name: species
       label: Species
       type: basic:string
@@ -157,7 +158,8 @@
           re-save-file unmapped_r "${NAME}_unmapped.out.mate2.fastq.gz"
       fi
 
-      bamtobigwig.sh "${NAME}.bam" {{ requirements.resources.cores }} 50
-
       re-save species {{ genome.species }}
       re-save build {{ genome.build }}
+
+      #computation time limit for bamCoverage is 480s per GB
+      bamtobigwig.sh "${NAME}.bam" {{ requirements.resources.cores }} 50 480

--- a/resolwe_bio/processes/alignment/star.yml
+++ b/resolwe_bio/processes/alignment/star.yml
@@ -14,7 +14,7 @@
       memory: 32768
       cores: 10
   data_name: "{{ reads|sample_name|default('?') }}"
-  version: 1.3.1
+  version: 1.3.2
   type: data:alignment:bam:star
   category: analyses:alignment
   flow_collection: sample
@@ -244,6 +244,7 @@
     - name: bigwig
       label: BigWig file
       type: basic:file
+      required: false
     - name: species
       label: Species
       type: basic:string
@@ -390,14 +391,17 @@
       mv Log.final.out "${READS_NAME}_stats.txt"
       mv SJ.out.tab "${READS_NAME}_SJ.out.tab"
 
-      bamtobigwig.sh "${READS_NAME}.bam" {{ requirements.resources.cores }} {{ output_sam_bam.bin_size_bigwig }}
-
       re-save-file bam "${READS_NAME}.bam"
       re-save-file bai "${READS_NAME}.bam.bai"
       re-save-file sj "${READS_NAME}_SJ.out.tab"
       re-save-file stats "${READS_NAME}_stats.txt"
       re-save species {{genome.species}}
       re-save build {{genome.build}}
+
+      #computation time limit for bamCoverage is 480s per GB
+      bamtobigwig.sh "${READS_NAME}.bam" {{ requirements.resources.cores }} {{ output_sam_bam.bin_size_bigwig }} 480
+
+
 
 
 - slug: alignment-star-index

--- a/resolwe_bio/processes/alignment/subread.yml
+++ b/resolwe_bio/processes/alignment/subread.yml
@@ -13,7 +13,7 @@
     resources:
       cores: 10
   data_name: "Alignment ({{ reads.fastq.0.file|basename|default('?') }})"
-  version: 2.0.1
+  version: 2.0.2
   type: data:alignment:bam:subread
   category: analyses:alignment
   flow_collection: sample
@@ -106,6 +106,7 @@
     - name: bigwig
       label: BigWig file
       type: basic:file
+      required: false
     - name: species
       label: Species
       type: basic:string
@@ -205,8 +206,9 @@
       re-save species {{genome.species}}
       re-save build {{genome.build}}
 
-      bamtobigwig.sh "${NAME}.bam" {{ requirements.resources.cores }} 50
-
       if [ -f "${NAME}_unmapped.fastq.gz" ]; then
         re-save-file unmapped "${NAME}_unmapped.fastq.gz"
       fi
+
+      #computation time limit for bamCoverage is 480s per GB
+      bamtobigwig.sh "${NAME}.bam" {{ requirements.resources.cores }} 50 480

--- a/resolwe_bio/processes/alignment/tophat.yml
+++ b/resolwe_bio/processes/alignment/tophat.yml
@@ -13,7 +13,7 @@
     resources:
       cores: 10
   data_name: "Alignment ({{ reads.fastq.0.file|basename|default('?') }})"
-  version: 2.1.2
+  version: 2.1.3
   type: data:alignment:bam:tophat
   category: analyses:alignment
   flow_collection: sample
@@ -151,6 +151,7 @@
     - name: bigwig
       label: BigWig file
       type: basic:file
+      required: false
     - name: species
       label: Species
       type: basic:string
@@ -234,8 +235,6 @@
       re-save species {{genome.species}}
       re-save build {{genome.build}}
 
-      bamtobigwig.sh "${NAME}.bam" {{ requirements.resources.cores }} 50
-
       if [ -f "${NAME}_unmapped.bam" ]; then
         re-save-file unmapped "${NAME}_unmapped.bam"
       fi
@@ -251,3 +250,7 @@
       if [ -f "${NAME}_insertions.bed" ]; then
         re-save-file insertions "${NAME}_insertions.bed"
       fi
+
+      #computation time limit for bamCoverage is 480s per GB
+      bamtobigwig.sh "${NAME}.bam" {{ requirements.resources.cores }} 50 480
+

--- a/resolwe_bio/tools/bamtobigwig.sh
+++ b/resolwe_bio/tools/bamtobigwig.sh
@@ -5,15 +5,28 @@ source /etc/profile.d/resolwe-base.sh
 bam_file="$1"
 number_of_cores="$2"
 bin_size="$3"
+time_limit="$4"
 
 NAME=`basename "${bam_file}" .bam`
 
-bamCoverage \
-  --binSize "${bin_size}" \
-  --bam "${bam_file}" \
-  --outFileName "${NAME}.bw" \
-  --outFileFormat "bigwig" \
-  --numberOfProcessors "${number_of_cores}"
-re-checkrc "Bam to BigWig failed."
+time_deeptools=`python -c "import os; print(max(os.path.getsize('${bam_file}') / 1024**3, 1) * ${time_limit})"`
 
-re-save-file bigwig "${NAME}.bw"
+timeout "${time_deeptools}" \
+  bamCoverage \
+    --binSize "${bin_size}" \
+    --bam "${bam_file}" \
+    --outFileName "${NAME}.bw" \
+    --outFileFormat "bigwig" \
+    --numberOfProcessors "${number_of_cores}"
+
+exit_status="$?"
+
+if [ ${exit_status} == 124 ]
+then
+  re-warning "BigWig took too long to process."
+elif [ ${exit_status} == 0 ]
+then
+  re-save-file bigwig "${NAME}.bw"
+else
+  re-checkrc "Calculation of BigWig failed."
+fi


### PR DESCRIPTION
## Checklist
<!--
Mark an `[x]` for completed items.
-->

* [x] Update CHANGELOG.rst for each commit separately:
  * Pay attention to write entries under the "Unreleased" section.
  * Mark all breaking changes as "**BACKWARD INCOMPATIBLE:**" and put them
    before non-breaking changes.
  * If a commit modifies a feature listed under "Unreleased" section,
    it might be sufficient to modify the existing CHANGELOG entry from previous
    commit(s).
* [x] Bump the process version:
  * **MAJOR version (first number)**: Backward incompatible changes (changes
    that break the api/interface). Examples: renaming the input/output, adding
    mandatory input, removing input/output...
  * **MINOR version (middle number)**: add functionality or changes in a
    backwards-compatible manner. Examples: add output field, add non-mandatory
    input parameter, use a different tool that produces same results...
  * **PATCH version (last number)**: changes/bug fixes that do not affect
    the api/interface. Examples: typo fix, change/add warning messages...
* [ ] All inputs are used in process.
* [x] All output fields have their ``re-save`` calls.
