### PR TITLE
Fix upload-gtf to covert GTF to GFF for JBrowse track

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -51,6 +51,9 @@ Fixed
   BBDuk - STAR - featureCounts workflow
 - Make ``cuffnorm`` process attach correct expression data objects to
   samples
+- Fix ``upload-gtf`` in a way that GTF can be shown in JBrowse. Because
+  JBrowse works only with GFF files, input GTF is converted to GFF from
+  which JBrowse track is created.
 
 
 ===================

--- a/resolwe_bio/processes/import_data/annotation.yml
+++ b/resolwe_bio/processes/import_data/annotation.yml
@@ -123,7 +123,7 @@
     resources:
       network: true
   data_name: '{{ src.file }}'
-  version: 3.1.0
+  version: 3.1.1
   type: data:annotation:gtf
   category: upload
   persistence: RAW
@@ -206,10 +206,12 @@
 
       igvtools sort "${NAME}".gtf "${NAME}"_sorted.gtf
       re-checkrc "Sorting of GTF file failed."
-      # add warning when GTF file is not acceptable by IGV, but can be used by other tool on platform
+      # add warning when GTF file is not acceptable by IGV, but can be used by other tools on platform
       igvtools index "${NAME}"_sorted.gtf || re-warning "Indexing of GTF file failed."
 
-      flatfile-to-json.pl --gff "${NAME}"_sorted.gtf --out . --trackLabel "annotation"
+      gffread "${NAME}"_sorted.gtf -o- > tmp.gff3
+      re-checkrc "Conversion to GFF3 for JBrowse failed."
+      flatfile-to-json.pl --gff tmp.gff3 --out . --trackLabel "annotation"
       re-checkrc "Annotation track processing for JBrowse failed."
 
       re-save-file annot "${NAME}.gtf"


### PR DESCRIPTION
## Checklist
<!--
Mark an `[x]` for completed items.
-->

* [x] Update CHANGELOG.rst for each commit separately:
  * Pay attention to write entries under the "Unreleased" section.
  * Mark all breaking changes as "**BACKWARD INCOMPATIBLE:**" and put them
    before non-breaking changes.
  * If a commit modifies a feature listed under "Unreleased" section,
    it might be sufficient to modify the existing CHANGELOG entry from previous
    commit(s).
* [x] Bump the process version:
  * **MAJOR version (first number)**: Backward incompatible changes (changes
    that break the api/interface). Examples: renaming the input/output, adding
    mandatory input, removing input/output...
  * **MINOR version (middle number)**: add functionality or changes in a
    backwards-compatible manner. Examples: add output field, add non-mandatory
    input parameter, use a different tool that produces same results...
  * **PATCH version (last number)**: changes/bug fixes that do not affect
    the api/interface. Examples: typo fix, change/add warning messages...
* [ ] All inputs are used in process.
* [ ] All output fields have their ``re-save`` calls.

