### PR TITLE
Fix upload-gtf to create JBrowse track only when GTF is ok

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -10,6 +10,9 @@ This project adheres to `Semantic Versioning <http://semver.org/>`_.
 Unreleased
 ==========
 
+Fixed
+-------
+- fix ``upload-gtf`` to create JBrowse track only if GTF file is ok
 
 ===================
 11.0.0 - 2018-07-17

--- a/resolwe_bio/processes/import_data/annotation.yml
+++ b/resolwe_bio/processes/import_data/annotation.yml
@@ -123,7 +123,7 @@
     resources:
       network: true
   data_name: '{{ src.file }}'
-  version: 3.1.1
+  version: 3.1.2
   type: data:annotation:gtf
   category: upload
   persistence: RAW
@@ -189,6 +189,7 @@
     - name: annot_sorted_track_jbrowse
       label: Jbrowse track for sorted GTF
       type: basic:file
+      required: false
     - name: source
       label: Gene ID database
       type: basic:string
@@ -211,12 +212,19 @@
 
       gffread "${NAME}"_sorted.gtf -o- > tmp.gff3
       re-checkrc "Conversion to GFF3 for JBrowse failed."
-      flatfile-to-json.pl --gff tmp.gff3 --out . --trackLabel "annotation"
-      re-checkrc "Annotation track processing for JBrowse failed."
+
+      # if tmp.gff3 file is not empty create JBrowse track
+      if [ -s tmp.gff3 ]
+      then
+        flatfile-to-json.pl --gff tmp.gff3 --out . --trackLabel "annotation"
+        re-checkrc "Annotation track processing for JBrowse failed."
+        re-save-file annot_sorted_track_jbrowse trackList.json tracks/annotation
+      else
+        re-warning "JBrowse track was not created. Please validate your GTF file."
+      fi
 
       re-save-file annot "${NAME}.gtf"
       re-save-file annot_sorted "${NAME}"_sorted.gtf
-      re-save-file annot_sorted_track_jbrowse trackList.json tracks/annotation
 
       if [ -f "${NAME}"_sorted.gtf.idx ]; then
          re-save-file annot_sorted_idx_igv "${NAME}"_sorted.gtf.idx


### PR DESCRIPTION
## Checklist
<!--
Mark an `[x]` for completed items.
-->

* [x] Update CHANGELOG.rst for each commit separately:
  * Pay attention to write entries under the "Unreleased" section.
  * Mark all breaking changes as "**BACKWARD INCOMPATIBLE:**" and put them
    before non-breaking changes.
  * If a commit modifies a feature listed under "Unreleased" section,
    it might be sufficient to modify the existing CHANGELOG entry from previous
    commit(s).
* [x] Bump the process version:
  * **MAJOR version (first number)**: Backward incompatible changes (changes
    that break the api/interface). Examples: renaming the input/output, adding
    mandatory input, removing input/output...
  * **MINOR version (middle number)**: add functionality or changes in a
    backwards-compatible manner. Examples: add output field, add non-mandatory
    input parameter, use a different tool that produces same results...
  * **PATCH version (last number)**: changes/bug fixes that do not affect
    the api/interface. Examples: typo fix, change/add warning messages...
* [ ] All inputs are used in process.
* [ ] All output fields have their ``re-save`` calls.
