### PR TITLE
WIP: Increase test timeout to 90 minutes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ throttle(["resolwe_bio"]) {
 
         // NOTE: Tests could hang unexpectedly and never release the Jenkins executor. Thus we set
         // a general timeout for tests' execution.
-        timeout(time: 60, unit: "MINUTES") {
+        timeout(time: 90, unit: "MINUTES") {
 
             try {
                 stage("Checkout") {


### PR DESCRIPTION
Testing the hypothesis that `resolwe-bio` tests fail simply because the runtime has increased (and not because of some other error, e.g. the semaphore issue).