### PR TITLE
Explicitly set image format in spikein_pairwise.py tool

### DIFF
--- a/resolwe_bio/processes/support_processors/spikeins_qc.yml
+++ b/resolwe_bio/processes/support_processors/spikeins_qc.yml
@@ -8,7 +8,7 @@
       docker:
         image: resolwebio/rnaseq:4.2.0
   data_name: 'Spike-ins QC ({% for s in samples %}{{ s | sample_name }}{{ ", " if not loop.last }}{% endfor %})'
-  version: 0.0.1
+  version: 0.0.2
   type: data:spikeins
   category: other
   persistence: CACHED

--- a/resolwe_bio/tests/processes/test_support_processors.py
+++ b/resolwe_bio/tests/processes/test_support_processors.py
@@ -396,7 +396,7 @@ class SupportProcessorTestCase(KBBioProcessTestCase):
             expression_3 = self.prepare_expression(
                 f_exp='exp3_cpm_ercc_sirv.tab.gz',
                 f_type='CPM',
-                name='Sample 3',
+                name='Sample3.txt',  # Test for sample names that might look like filename extensions
                 source='ENSEMBL',
                 species='Homo sapiens')
             expression_4 = self.prepare_expression(
@@ -421,7 +421,7 @@ class SupportProcessorTestCase(KBBioProcessTestCase):
         self.assertEqual(expected_names, [
             "Sample 1 (ERCC spike-in's).png",
             "Sample 2 (ERCC spike-in's).png",
-            "Sample 3 (ERCC spike-in's).png",
+            "Sample3.txt (ERCC spike-in's).png",
         ])
 
         self.assertFileExists(sirv_set3, 'report')

--- a/resolwe_bio/tools/spikein_pairwise.py
+++ b/resolwe_bio/tools/spikein_pairwise.py
@@ -207,7 +207,7 @@ def plot_histogram_scatter(expected, zero, nonzero, spikein_type, sample_name, e
     )
     title = "{} ({} spike-in's)".format(sample_name, spikein_type)
     fig.suptitle(title)
-    plt.savefig(title)
+    plt.savefig(title + '.png', format='png')
     plt.close()
 
 


### PR DESCRIPTION
This fixes the error that appeared if sample name contained dots.
The presence of dots in sample name (and absence of format
parameter in savefig method) caused matplotlib to autmatically
determine format. It took the part of sample name that is following
the last dot as a file extension.
