### PR TITLE
Add shRNAde R package to rnaseq docker image

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -10,6 +10,10 @@ This project adheres to `Semantic Versioning <http://semver.org/>`_.
 Unreleased
 ==========
 
+Added
+-----
+- Add shRNAde (v1.0) R package to the ``resolwebio/rnaseq:4.4.0`` Docker image
+
 Changed
 -------
 - **BACKWARD INCOMPATIBLE:** Require Resolwe 16.x
@@ -58,8 +62,6 @@ Changed
   the default expression normalization type (``exp_type``) using the
   ``normalization_type`` input.
 - Bump MultiQC to version 1.7.0 in ``multiqc`` process
-- Use ``resolwebio/common:1.1.0`` base image for the
-  ``resolwebio/rnaseq:4.3.0`` Docker image
 - Use ``resolwebio/rnaseq:4.3.0`` with Subread/featureCounts version
   1.6.3 in ``feature_counts`` process
 

--- a/resolwe_bio/docker_images/rnaseq/README.md
+++ b/resolwe_bio/docker_images/rnaseq/README.md
@@ -26,3 +26,4 @@ Included bioinformatics tools:
 * STAR (v2.7.0c)
 * Trimmomatic (v0.36)
 * tximport (v1.6.0)
+* shRNAde (v1.0)

--- a/resolwe_bio/docker_images/rnaseq/packages-manual/r-packages.sh
+++ b/resolwe_bio/docker_images/rnaseq/packages-manual/r-packages.sh
@@ -14,4 +14,5 @@ Rscript --slave --no-save --no-restore-history -e " \
   library(devtools); \
   install_github('jkokosar/RNASeqT'); \
   install_github('jvrakor/Subread_to_DEXSeq', subdir = 'loadSubread'); \
+  install_github('genialis/shRNAde'); \
 "


### PR DESCRIPTION
An R package has been developed in order to serve the functionality of the short hairpin RNA differential expression process. This PR puts this package into `rnaseq` image. I think the docker image should be tagged as 4.4.0.