### PR TITLE
Fix WES bam validation issues

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -23,6 +23,8 @@ Changed
   Salmon tool (``library-strandedness``, ``feature_counts`` and
   ``qorts-qc``)
 - Implement dropdown menu for ``upload-bedpe`` process
+- Add validation stringency parameter to ``bqsr`` process and propagate
+  it to the ``workflow-wes`` as well
 
 Added
 -----

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -22,6 +22,7 @@ Changed
 - Use ``resolwebio/rnaseq:4.5.0`` Docker image in processes that call
   Salmon tool (``library-strandedness``, ``feature_counts`` and
   ``qorts-qc``)
+- Implement dropdown menu for ``upload-bedpe`` process
 
 Added
 -----

--- a/resolwe_bio/processes/import_data/annotation_bedpe.py
+++ b/resolwe_bio/processes/import_data/annotation_bedpe.py
@@ -10,7 +10,7 @@ class ImportBEDPEFile(Process):
     name = 'BEDPE file'
     process_type = 'data:bedpe:'
     data_name = '{{ src.file|default("?") }}'
-    version = '1.0.0'
+    version = '1.0.1'
     category = 'Import'
     requirements = {
         'expression-engine': 'jinja',
@@ -30,7 +30,17 @@ class ImportBEDPEFile(Process):
         """Input parameters."""
 
         src = FileField(label='Select BEDPE file to upload')
-        species = StringField(label='Species')
+        species = StringField(
+            label='Species',
+            choices=[
+                ('Homo sapiens', 'Homo sapiens'),
+                ('Mus musculus', 'Mus musculus'),
+                ('Rattus norvegicus', 'Rattus norvegicus'),
+                ('Dictyostelium discoideum', 'Dictyostelium discoideum'),
+                ('Odocoileus virginianus texanus', 'Odocoileus virginianus texanus'),
+                ('Solanum tuberosum', 'Solanum tuberosum'),
+            ]
+        )
         build = StringField(label='Build')
 
     class Output:

--- a/resolwe_bio/processes/workflows/wes.yml
+++ b/resolwe_bio/processes/workflows/wes.yml
@@ -3,9 +3,24 @@
   data_name: "{{ reads|sample_name|default('?') }}"
   requirements:
     expression-engine: jinja
-  version: 1.0.0
+  version: 2.0.0
   type: data:workflow:wes
   category: Pipeline
+  description: |
+    Whole exome sequencing pipeline analyzes Illumina panel data. It consists of trimming, aligning, soft clipping,
+    (optional) marking of duplicates, recalibration of base quality scores and finally, calling of variants.
+
+    The tools used are Trimmomatic which performs trimming. Aligning is performed using BWA (mem). Soft clipping of
+    Illumina primer sequences is done using bamclipper tool. Marking of duplicates (MarkDuplicates), recalibration of
+    base quality scores (ApplyBQSR) and calling of variants (HaplotypeCaller) is done using GATK4 bundle of
+    bioinformatics tools.
+
+    To successfully run this pipeline, you will need a genome (FASTA), paired-end (FASTQ) files, BEDPE file for
+    bamclipper, known sites of variation (dbSNP) (VCF), dbSNP database of variations (can be the same as known sites of
+    variation), intervals on which target capture was done (BED) and illumina adapter sequences (FASTA). Make sure that
+    specified resources match the genome used in the alignment step.
+
+    Result is a file of called variants (VCF).
   input:
     - name: reads
       label: Raw untrimmed reads
@@ -45,6 +60,20 @@
       required: true
       description: |
         dbSNP database of variants for variant calling.
+    - name: validation_stringency
+      label: Validation stringency for all SAM files read by this program. Setting stringency to SILENT
+        can improve performance when processing a BAM file in which variable-length data (read,
+        qualities, tags) do not otherwise need to be decoded. Default is STRICT. This setting is used
+        in BaseRecalibrator and ApplyBQSR processes.
+      type: basic:string
+      default: STRICT
+      choices:
+        - label: STRICT
+          value: STRICT
+        - label: SILENT
+          value: SILENT
+        - label: LENIENT
+          value: LENIENT
     - name: advanced
       label: Advanced parameters
       group:
@@ -199,15 +228,6 @@
               label: Remove found duplicates
               type: basic:boolean
               default: false
-            - name: md_validation_stringency
-              label: Validation stringency
-              type: basic:string
-              default: STRICT
-              choices:
-                - label: STRICT
-                  value: STRICT
-                - label: SILENT
-                  value: SILENT
             - name: md_assume_sort_order
               label: Assume sort oder
               type: basic:string
@@ -237,10 +257,9 @@
                 the user to replace all read groups in the INPUT file with a single new read group and assign all
                 reads to this read group in the OUTPUT BAM file. Addition or replacement is performed using
                 Picard's AddOrReplaceReadGroups tool. Input should take the form of -name=value delimited by a
-                \t, e.g. "-ID=1\t-PL=Illumina\t-SM=sample_1". See [tool's documentation](https://software
-                .broadinstitute.org/gatk/documentation/tooldocs/4.0.11.0/picard_sam_AddOrReplaceReadGroups.php) for
-                more information on tag names. Note that PL, LB, PU and SM are require fields. See caveats of
-                rewriting read groups in the documentation linked above.
+                \t, e.g. "-ID=1\t-PL=Illumina\t-SM=sample_1". See AddOrReplaceReadGroups documentation for more
+                information on tag names. Note that PL, LB, PU and SM are required fields. See caveats of rewriting
+                read groups in the documentation linked above.
         - name: hc
           label: HaplotypeCaller parameters
           group:
@@ -303,7 +322,7 @@
           bam: '{{ steps.bamclipper }}'
           skip: '{{ input.advanced.markduplicates.md_skip }}'
           remove_duplicates: '{{ input.advanced.markduplicates.md_remove_duplicates }}'
-          validation_stringency: '{{ input.advanced.markduplicates.md_validation_stringency }}'
+          validation_stringency: '{{ input.validation_stringency }}'
           assume_sort_order: '{{ input.advanced.markduplicates.md_assume_sort_order }}'
       - id: bqsr
         run: bqsr
@@ -313,6 +332,7 @@
           known_sites: '{{ input.known_sites }}'
           intervals: '{{ input.intervals }}'
           read_group: '{{ input.advanced.bqsr.read_group }}'
+          validation_stringency: '{{ input.validation_stringency }}'
       - id: hc
         run: vc-gatk4-hc
         input:

--- a/resolwe_bio/tests/processes/test_reads_filtering.py
+++ b/resolwe_bio/tests/processes/test_reads_filtering.py
@@ -1,4 +1,5 @@
 # pylint: disable=missing-docstring
+from resolwe.flow.models import Data
 from resolwe.test import tag_process
 from resolwe_bio.utils.test import BioProcessTestCase
 
@@ -346,3 +347,7 @@ class ReadsFilteringProcessorTestCase(BioProcessTestCase):
 
             self.assertFileExists(bqsr_rg, 'bam')
             self.assertFileExists(bqsr_rg, 'bai')
+
+            bqsr_inputs['read_group'] = '-LB=DAB;-PL=Illumina;-PU=barcode;-SM=sample1;-SM=sample2'
+            bqsr_dbltag = self.run_process('bqsr', bqsr_inputs, Data.STATUS_ERROR)
+            self.assertEqual(bqsr_dbltag.process_error[0], 'You have duplicate tags in read_group argument.')

--- a/resolwe_bio/tests/workflows/test_wes.py
+++ b/resolwe_bio/tests/workflows/test_wes.py
@@ -48,6 +48,7 @@ class WESTestCase(BioProcessTestCase):
             'known_sites': [i.id for i in kbase],
             'intervals': intervals.id,
             'hc_dbsnp': kbase[0].id,
+            'validation_stringency': 'LENIENT',
             'advanced': {
                 'trimming': {
                     'adapters': adapters.id,
@@ -77,7 +78,6 @@ class WESTestCase(BioProcessTestCase):
                 'markduplicates': {
                     'md_skip': False,
                     'md_remove_duplicates': False,
-                    'md_validation_stringency': 'STRICT',
                     'md_assume_sort_order': ''
                 },
                 'bqsr': {


### PR DESCRIPTION
This PR adds a dropdown menu to `upload-bedpe` process. Selection of species name can now be done like for any other process.

Because some bam files are not structured the way certain tools want them, a validation stringency parameter has been introduced into all subprocesses called within the `bqsr` process.

## Checklist

* [x] Update CHANGELOG.rst for each commit separately:
  * Pay attention to write entries under the "Unreleased" section.
  * Mark all breaking changes as "**BACKWARD INCOMPATIBLE:**" and put them
    before non-breaking changes.
  * If a commit modifies a feature listed under "Unreleased" section,
    it might be sufficient to modify the existing CHANGELOG entry from previous
    commit(s).
* [x] Bump the process version:
  * **MAJOR version (first number)**: Backward incompatible changes (changes
    that break the api/interface). Examples: renaming the input/output, adding
    mandatory input, removing input/output...
  * **MINOR version (middle number)**: add functionality or changes in a
    backwards-compatible manner. Examples: add output field, add non-mandatory
    input parameter, use a different tool that produces same results...
  * **PATCH version (last number)**: changes/bug fixes that do not affect
    the api/interface. Examples: typo fix, change/add warning messages...
* [x] All inputs are used in process.
* [x] All output fields have their ``re-save`` calls.
