### PR TITLE
Bump version in markduplicates process

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -25,6 +25,8 @@ Changed
 - Implement dropdown menu for ``upload-bedpe`` process
 - Add validation stringency parameter to ``bqsr`` process and propagate
   it to the ``workflow-wes`` as well
+- Add LENIENT value to validation stringency parameter of the ``markduplicates``
+  process
 
 Added
 -----

--- a/resolwe_bio/processes/reads_processing/markduplicates.py
+++ b/resolwe_bio/processes/reads_processing/markduplicates.py
@@ -15,7 +15,7 @@ class MarkDuplicates(Process):
     slug = 'markduplicates'
     name = 'MarkDuplicates'
     process_type = 'data:alignment:bam:markduplicate:'
-    version = '1.0.1'
+    version = '1.1.0'
     category = 'BAM processing'
     shaduling_class = SchedulingClass.BATCH
     entity = {'type': 'sample'}


### PR DESCRIPTION
Because I forgot to bump version of `markduplicates` process the pipeline was failing when I added another value (`LENIENT`) to parameter of `validation_stringency`. This is now also documented in the changelog.

## Checklist
<!--
Mark an `[x]` for completed items.
-->

* [x] Update CHANGELOG.rst for each commit separately:
  * Pay attention to write entries under the "Unreleased" section.
  * Mark all breaking changes as "**BACKWARD INCOMPATIBLE:**" and put them
    before non-breaking changes.
  * If a commit modifies a feature listed under "Unreleased" section,
    it might be sufficient to modify the existing CHANGELOG entry from previous
    commit(s).
* [x] Bump the process version:
  * **MAJOR version (first number)**: Backward incompatible changes (changes
    that break the api/interface). Examples: renaming the input/output, adding
    mandatory input, removing input/output...
  * **MINOR version (middle number)**: add functionality or changes in a
    backwards-compatible manner. Examples: add output field, add non-mandatory
    input parameter, use a different tool that produces same results...
  * **PATCH version (last number)**: changes/bug fixes that do not affect
    the api/interface. Examples: typo fix, change/add warning messages...
* [x] All inputs are used in process.
* [x] All output fields have their ``re-save`` calls.