### PR TITLE
Update build status icon

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,8 +4,8 @@ Resolwe Bioinformatics
 
 |build| |coverage| |docs| |pypi_version| |pypi_pyversions|
 
-.. |build| image:: https://ci.genialis.io/buildStatus/icon?job=genialis-github/resolwe-bio/master
-    :target: https://ci.genialis.io/job/resolwe-bio/job/master/
+.. |build| image:: https://public.ci.genialis.io/buildStatus/icon/resolwe-bio/master
+    :target: https://ci.genialis.io/blue/organizations/jenkins/resolwe-bio/activity
     :alt: Build Status
 
 .. |coverage| image:: https://img.shields.io/codecov/c/github/genialis/resolwe-bio/master.svg


### PR DESCRIPTION
- Status icon in README is updated to work with the two-step authentication on the new Jenkins server.
- When the build status is clicked, link points to the new Blue Ocean interface instead of the old Jenkins interface.

![readme-icon](https://user-images.githubusercontent.com/8665160/61216030-b20aa900-a70c-11e9-8ef5-04c21b79319d.png)
