### PR TITLE
Add skip parameter to bamclipper process and wes-pipeline workflow

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -24,6 +24,8 @@ Added
 -----
 - Add ``cutadapt-3prime-single`` process
 - Add ``workflow-cutadapt-star-fc-quant-single`` process
+- Add argument ``skip`` to ``bamclipper`` which enables skipping of
+  the said process
 
 
 ===================

--- a/resolwe_bio/processes/workflows/wes.yml
+++ b/resolwe_bio/processes/workflows/wes.yml
@@ -3,7 +3,7 @@
   data_name: "{{ reads|sample_name|default('?') }}"
   requirements:
     expression-engine: jinja
-  version: 2.0.0
+  version: 2.1.0
   type: data:workflow:wes
   category: Pipeline
   description: |
@@ -34,13 +34,6 @@
       required: true
       description: |
         Against which genome to align. Further processes depend on this genome (e.g. BQSR step).
-    # bamclipper
-    - name: bamclipper_bedpe
-      label: BEDPE file used for clipping using Bamclipper
-      type: data:bedpe
-      required: true
-      description: |
-        BEDPE file used for clipping using Bamclipper tool.
     # bqsr
     - name: known_sites
       label: Known sites of variation used in BQSR
@@ -217,6 +210,21 @@
               default: 30
               description: |
                 Don't output alignment with score lower than defined number. This option only affects output.
+        - name: bamclipper
+          label: Bamclipper parameters
+          group:
+            - name: bedpe
+              label: BEDPE file used for clipping using Bamclipper
+              type: data:bedpe
+              required: false
+              description: |
+                BEDPE file used for clipping using Bamclipper tool.
+            - name: skip
+              label: Skip Bamclipper step
+              type: basic:boolean
+              default: false
+              description: |
+                Use this option to skip Bamclipper step.
         - name: markduplicates
           label: MarkDuplicates parameters
           group:
@@ -315,7 +323,8 @@
         run: bamclipper
         input:
           alignment: '{{ steps.bwa }}'
-          bedpe: '{{ input.bamclipper_bedpe }}'
+          bedpe: '{{ input.advanced.bamclipper.bedpe }}'
+          skip: '{{ input.advanced.bamclipper.skip }}'
       - id: markduplicates
         run: markduplicates
         input:

--- a/resolwe_bio/tests/processes/test_reads_filtering.py
+++ b/resolwe_bio/tests/processes/test_reads_filtering.py
@@ -259,10 +259,11 @@ class ReadsFilteringProcessorTestCase(BioProcessTestCase):
     def test_bamclipper(self):
         species = 'Homo sapiens'
         build = 'fake_genome_RSEM'
+        align_input = './bamclipper/input/STK11.bam'
 
         with self.preparation_stage():
             bam = self.prepare_bam(
-                fn='./bamclipper/input/STK11.bam',
+                fn=align_input,
                 species=species,
                 build=build
             )
@@ -271,6 +272,14 @@ class ReadsFilteringProcessorTestCase(BioProcessTestCase):
                             'species': species, 'build': build}
             bedpe = self.run_process('upload-bedpe', inputs_bedpe)
 
+        # Test if bamclipper has been skipped.
+        bc_skip_inputs = {'alignment': bam.id, 'skip': True}
+        skipped_bc = self.run_process('bamclipper', bc_skip_inputs)
+        self.assertFile(skipped_bc, 'bam', align_input)
+        bc_data = Data.objects.last()
+        self.assertEqual(bc_data.process_info, ['Skipping bamclipper step.'])
+
+        # Test bamclipper.
         inputs_bamclipper = {'alignment': bam.id, 'bedpe': bedpe.id}
         clipped = self.run_process('bamclipper', inputs_bamclipper)
 

--- a/resolwe_bio/tests/workflows/test_wes.py
+++ b/resolwe_bio/tests/workflows/test_wes.py
@@ -44,7 +44,6 @@ class WESTestCase(BioProcessTestCase):
         input_workflow = {
             'reads': reads.pk,
             'genome': genome.id,
-            'bamclipper_bedpe': bc_bedpe.id,
             'known_sites': [i.id for i in kbase],
             'intervals': intervals.id,
             'hc_dbsnp': kbase[0].id,
@@ -75,6 +74,10 @@ class WESTestCase(BioProcessTestCase):
                     },
                     'report_tr': 30
                 },
+                'bamclipper': {
+                    'bedpe': bc_bedpe.id,
+                    'skip': False
+                },
                 'markduplicates': {
                     'md_skip': False,
                     'md_remove_duplicates': False,
@@ -93,3 +96,11 @@ class WESTestCase(BioProcessTestCase):
         self.run_process('workflow-wes', input_workflow)
         wes = Data.objects.last()
         self.assertFileExists(wes, 'vcf')
+
+        # Test skipping bamclipper
+        input_workflow_skipbc = input_workflow
+        input_workflow_skipbc['advanced']['bamclipper']['skip'] = True
+        self.run_process('workflow-wes', input_workflow_skipbc)
+        wes_skip = Data.objects.filter(process__slug='bamclipper').last()
+
+        self.assertEqual(wes_skip.process_info, ['Skipping bamclipper step.'])


### PR DESCRIPTION
This PR adds a skip parameter to `bamclipper` tool. This enables the WES pipeline to process not only data from amplicon based kits, but also hybridization based kits.

## Checklist
* [x] Update CHANGELOG.rst for each commit separately:
  * Pay attention to write entries under the "Unreleased" section.
  * Mark all breaking changes as "**BACKWARD INCOMPATIBLE:**" and put them
    before non-breaking changes.
  * If a commit modifies a feature listed under "Unreleased" section,
    it might be sufficient to modify the existing CHANGELOG entry from previous
    commit(s).
* [x] Bump the process version:
  * **MAJOR version (first number)**: Backward incompatible changes (changes
    that break the api/interface). Examples: renaming the input/output, adding
    mandatory input, removing input/output...
  * **MINOR version (middle number)**: add functionality or changes in a
    backwards-compatible manner. Examples: add output field, add non-mandatory
    input parameter, use a different tool that produces same results...
  * **PATCH version (last number)**: changes/bug fixes that do not affect
    the api/interface. Examples: typo fix, change/add warning messages...
* [x] All inputs are used in process.
* [x] All output fields have their ``re-save`` calls.
