### PR TITLE
Remove BG command  modifier in Cutadapt processes

### DIFF
--- a/resolwe_bio/processes/reads_processing/cutadapt_3prime.py
+++ b/resolwe_bio/processes/reads_processing/cutadapt_3prime.py
@@ -2,7 +2,7 @@
 import os
 import shutil
 
-from plumbum import BG, TEE
+from plumbum import TEE
 
 from resolwe.process import (
     Process,
@@ -23,7 +23,7 @@ class Cutadapt3Prime(Process):
     slug = 'cutadapt-3prime-single'
     name = "Cutadapt (3' mRNA-seq, single-end)"
     process_type = 'data:reads:fastq:single:cutadapt:'
-    version = '1.0.0'
+    version = '1.0.1'
     category = 'Other'
     shaduling_class = SchedulingClass.BATCH
     entity = {'type': 'sample'}
@@ -134,8 +134,11 @@ class Cutadapt3Prime(Process):
         ]
 
         # Run Cutadapt, write analysis reports into a report file
-        (Cmd['cutadapt'][first_pass_input] | Cmd['cutadapt'][second_pass_input] | Cmd['cutadapt'][third_pass_input]) \
-            & BG(stdout=open('cutadapt_report.txt', 'a'), stderr=open('cutadapt_report.txt', 'a'))
+        (
+            Cmd['cutadapt'][first_pass_input]
+            | Cmd['cutadapt'][second_pass_input]
+            | Cmd['cutadapt'][third_pass_input] > 'cutadapt_report.txt'
+        )()
 
         # Prepare final FASTQC report
         fastqc_args = ['{}_trimmed.fastq.gz'.format(name), 'fastqc', 'fastqc_archive', 'fastqc_url', '--nogroup']

--- a/resolwe_bio/processes/reads_processing/cutadapt_corall.py
+++ b/resolwe_bio/processes/reads_processing/cutadapt_corall.py
@@ -2,7 +2,7 @@
 import os
 import shutil
 
-from plumbum import BG, TEE
+from plumbum import TEE
 
 from resolwe.process import (
     Process,
@@ -26,7 +26,7 @@ class CutadaptCorallSingle(Process):
     slug = 'cutadapt-corall-single'
     name = "Cutadapt (Corall RNA-Seq, single-end)"
     process_type = 'data:reads:fastq:single:cutadapt:'
-    version = '1.0.0'
+    version = '1.0.1'
     category = 'Other'
     shaduling_class = SchedulingClass.BATCH
     entity = {'type': 'sample'}
@@ -148,8 +148,8 @@ class CutadaptCorallSingle(Process):
             Cmd['cutadapt'][first_pass_input]
             | Cmd['cutadapt'][second_pass_input]
             | Cmd['cutadapt'][third_pass_input]
-            | Cmd['cutadapt'][fourth_pass_input]
-        ) & BG(stdout=open('cutadapt_report.txt', 'a'), stderr=open('cutadapt_report.txt', 'a'))
+            | Cmd['cutadapt'][fourth_pass_input] > 'cutadapt_report.txt'
+        )()
 
         # Prepare final FASTQC report
         fastqc_args = ['{}_trimmed.fastq.gz'.format(name), 'fastqc', 'fastqc_archive', 'fastqc_url', '--nogroup']
@@ -171,7 +171,7 @@ class CutadaptCorallPaired(Process):
     slug = 'cutadapt-corall-paired'
     name = "Cutadapt (Corall RNA-Seq, paired-end)"
     process_type = 'data:reads:fastq:paired:cutadapt:'
-    version = '1.0.0'
+    version = '1.0.1'
     category = 'Other'
     shaduling_class = SchedulingClass.BATCH
     entity = {'type': 'sample'}
@@ -313,8 +313,8 @@ class CutadaptCorallPaired(Process):
             Cmd['cutadapt'][first_pass_input]
             | Cmd['cutadapt'][second_pass_input]
             | Cmd['cutadapt'][third_pass_input]
-            | Cmd['cutadapt'][fourth_pass_input]
-        ) & BG(stdout=open('cutadapt_report.txt', 'a'), stderr=open('cutadapt_report.txt', 'a'))
+            | Cmd['cutadapt'][fourth_pass_input] > 'cutadapt_report.txt'
+        )()
 
         # Prepare final FASTQC report
         fastqc_args = ['{}_trimmed.fastq.gz'.format(name_mate1), 'fastqc', 'fastqc_archive', 'fastqc_url']


### PR DESCRIPTION
The use of Plumbum's BG command modifier causes IO input stream errors when incomplete output files were passed to FASTQC process downstream of Cutadapt. I have reverted to the default use of Plumbum, with the downside of cutadapt_report.txt file now holding stdout info for just the last of the multiple calls to Cutadapt.