### PR TITLE
Add network access to upload-bedpe process

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -28,6 +28,9 @@ Added
 - Add ``workflow-bbduk-salmon-qc-single`` and
   ``workflow-bbduk-salmon-qc-paired`` workflows
 
+Fixed
+-----
+- Give process ``upload-bedpe`` access to network
 
 ===================
 22.0.0 - 2019-08-20

--- a/resolwe_bio/processes/import_data/annotation_bedpe.py
+++ b/resolwe_bio/processes/import_data/annotation_bedpe.py
@@ -10,7 +10,7 @@ class ImportBEDPEFile(Process):
     name = 'BEDPE file'
     process_type = 'data:bedpe:'
     data_name = '{{ src.file|default("?") }}'
-    version = '1.0.1'
+    version = '1.0.2'
     category = 'Import'
     requirements = {
         'expression-engine': 'jinja',
@@ -22,6 +22,7 @@ class ImportBEDPEFile(Process):
         'resources': {
             'cores': 1,
             'memory': 1024,
+            'network': True,
         },
     }
     scheduling_class = SchedulingClass.BATCH


### PR DESCRIPTION
This pull request grants access to network for process `upload-bedpe` to enable uploading of files from the internet.

## Checklist
* [x] Update CHANGELOG.rst for each commit separately:
  * Pay attention to write entries under the "Unreleased" section.
  * Mark all breaking changes as "**BACKWARD INCOMPATIBLE:**" and put them
    before non-breaking changes.
  * If a commit modifies a feature listed under "Unreleased" section,
    it might be sufficient to modify the existing CHANGELOG entry from previous
    commit(s).
* [x] Bump the process version:
  * **MAJOR version (first number)**: Backward incompatible changes (changes
    that break the api/interface). Examples: renaming the input/output, adding
    mandatory input, removing input/output...
  * **MINOR version (middle number)**: add functionality or changes in a
    backwards-compatible manner. Examples: add output field, add non-mandatory
    input parameter, use a different tool that produces same results...
  * **PATCH version (last number)**: changes/bug fixes that do not affect
    the api/interface. Examples: typo fix, change/add warning messages...
* [x] All inputs are used in process.
* [x] All output fields have their ``re-save`` calls.