### PR TITLE
Rename workflow-trim-align-quant to make it more informative

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -6,6 +6,22 @@ All notable changes to this project are documented in this file.
 This project adheres to `Semantic Versioning <http://semver.org/>`_.
 
 
+==========
+Unreleased
+==========
+
+Added
+-----
+
+Changed
+-------
+- Renamed ``workflow-trim-align-quant`` workflow to make it more
+  informative
+
+Fixed
+-----
+
+
 ===================
 23.1.0 - 2019-09-30
 ===================

--- a/resolwe_bio/processes/workflows/trim-align-quant.yml
+++ b/resolwe_bio/processes/workflows/trim-align-quant.yml
@@ -1,9 +1,9 @@
 - slug: workflow-trim-align-quant
-  name: Trim, align and quantify using a library as a reference.
+  name: shRNA quantification
   data_name: "{{ reads|sample_name|default('?') }}"
   requirements:
     expression-engine: jinja
-  version: 0.0.2
+  version: 0.0.3
   type: data:workflow:trimalquant
   category: Pipeline
   input:


### PR DESCRIPTION
A  minor change where name of the `workflow-trim-align-quant` is changed so that it is more informative.

## Checklist
<!--
Mark an `[x]` for completed items.
-->

* [x] Update CHANGELOG.rst for each commit separately:
  * Pay attention to write entries under the "Unreleased" section.
  * Mark all breaking changes as "**BACKWARD INCOMPATIBLE:**" and put them
    before non-breaking changes.
  * If a commit modifies a feature listed under "Unreleased" section,
    it might be sufficient to modify the existing CHANGELOG entry from previous
    commit(s).
* [x] Bump the process version:
  * **MAJOR version (first number)**: Backward incompatible changes (changes
    that break the api/interface). Examples: renaming the input/output, adding
    mandatory input, removing input/output...
  * **MINOR version (middle number)**: add functionality or changes in a
    backwards-compatible manner. Examples: add output field, add non-mandatory
    input parameter, use a different tool that produces same results...
  * **PATCH version (last number)**: changes/bug fixes that do not affect
    the api/interface. Examples: typo fix, change/add warning messages...
* [x] All inputs are used in process.
* [x] All output fields have their ``re-save`` calls.
