### PR TITLE
Star samtools sort

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -32,6 +32,8 @@ Changed
 - Freeze docutils package version to 0.15.2 because Sphinx has
   problems parsing development version numbers
 - Support Slamdunk/Alleyoop processes in MultiQC
+- Enable sorting of files in ``alignment-star`` process using samtools
+
 
 ===================
 24.0.0 - 2019-11-15

--- a/resolwe_bio/processes/alignment/star.yml
+++ b/resolwe_bio/processes/alignment/star.yml
@@ -14,7 +14,7 @@
       memory: 36864
       cores: 10
   data_name: "{{ reads|sample_name|default('?') }}"
-  version: 1.8.12
+  version: 1.9.0
   type: data:alignment:bam:star
   category: Align
   flow_collection: sample
@@ -305,6 +305,12 @@
           description: |
             Size of the bins, in bases, for the output of the bigwig. Only possible if 'Tool to calculate BigWig'
             is deepTools. If BigWig is calculated by UCSC BedGraphToBigWig then bin size is 1.
+    - name: star_sort
+      label: Sorting with STAR
+      type: basic:boolean
+      default: false
+      description: |
+        Set to false for sorting with samtools or to true for sorting with STAR which may be time and memory intensive.
   output:
     - name: bam
       label: Alignment file
@@ -380,9 +386,9 @@
           --runThreadN {{requirements.resources.cores}} \
           --genomeDir "${INDEX}" \
           --readFilesIn mate1.fastq \
-          --outSAMtype BAM SortedByCoordinate \
           --outReadsUnmapped Fastx \
-          --limitBAMsortRAM {{(requirements.resources.memory * 1024 * 1024 * 0.9)|int}} \
+          {% if star_sort %}--outSAMtype BAM SortedByCoordinate {% else %} --outSAMtype BAM Unsorted {% endif %} \
+          {% if star_sort %}--limitBAMsortRAM {{(requirements.resources.memory * 1024 * 1024 * 0.9)|int}} {% endif %} \
           {% if annotation %}--sjdbGTFfile {{ annotation.annot.file }} {% endif %} \
           {% if annotation|type|subtype('data:annotation:gff3') %}--sjdbGTFtagExonParentTranscript Parent{% endif %} \
           {% if annotation %}--sjdbOverhang {{ annotation_options.sjdbOverhang }} {% endif %} \
@@ -421,9 +427,9 @@
           --runThreadN {{requirements.resources.cores}} \
           --genomeDir "${INDEX}" \
           --readFilesIn mate1.fastq mate2.fastq \
-          --outSAMtype BAM SortedByCoordinate \
           --outReadsUnmapped Fastx \
-          --limitBAMsortRAM {{(requirements.resources.memory * 1024 * 1024 * 0.9)|int}} \
+          {% if star_sort %}--outSAMtype BAM SortedByCoordinate {% else %} --outSAMtype BAM Unsorted {% endif %} \
+          {% if star_sort %}--limitBAMsortRAM {{(requirements.resources.memory * 1024 * 1024 * 0.9)|int}} {% endif %} \
           {% if annotation %}--sjdbGTFfile {{ annotation.annot.file }} {% endif %} \
           {% if annotation|type|subtype('data:annotation:gff3') %}--sjdbGTFtagExonParentTranscript Parent{% endif %} \
           {% if annotation %}--sjdbOverhang {{ annotation_options.sjdbOverhang }} {% endif %} \
@@ -467,20 +473,21 @@
       {% endif %}
       re-progress 0.8
 
-      # If alignment job produces an empty .bam file, the file needs to be re-sorted
-      # for it to be successfully indexed by samtools.
-      if [[ $(samtools view -c Aligned.sortedByCoord.out.bam) == 0 ]]
-      then
-        samtools sort Aligned.sortedByCoord.out.bam > Aligned.sortedByCoord_temp.out.bam
-        re-checkrc "Samtools sort command failed."
-        samtools index Aligned.sortedByCoord_temp.out.bam "${MATE1_NAME}.bam.bai"
-        re-checkrc "Samtools index command failed."
-        mv Aligned.sortedByCoord_temp.out.bam "${MATE1_NAME}.bam"
-      else
-        samtools index Aligned.sortedByCoord.out.bam "${MATE1_NAME}.bam.bai"
-        re-checkrc "Samtools index command failed."
-        mv Aligned.sortedByCoord.out.bam "${MATE1_NAME}.bam"
-      fi
+      OUT_NAME="${MATE1_NAME}.bam"
+      OUT_NAME_BAI="${OUT_NAME}.bai"
+      OUT_NAME_TEMP="${OUT_NAME}_temp"
+
+      {% if star_sort %}
+          IN_NAME="Aligned.sortedByCoord.out.bam"
+      {% else %}
+          IN_NAME="Aligned.out.bam"
+      {% endif %}
+
+      samtools sort "${IN_NAME}" -o "${OUT_NAME_TEMP}" -@ {{requirements.resources.cores}}
+      re-checkrc "Samtools sort command failed."
+      samtools index "${OUT_NAME_TEMP}" "${OUT_NAME_BAI}"
+      re-checkrc "Samtools index command failed."
+      mv "${OUT_NAME_TEMP}" "${OUT_NAME}"
       re-progress 0.9
 
       {% if detect_chimeric.chimeric %}
@@ -511,8 +518,8 @@
       mv Log.final.out "${MATE1_NAME}_stats.txt"
       mv SJ.out.tab "${MATE1_NAME}_SJ.out.tab"
 
-      re-save-file bam "${MATE1_NAME}.bam"
-      re-save-file bai "${MATE1_NAME}.bam.bai"
+      re-save-file bam "${OUT_NAME}"
+      re-save-file bai "${OUT_NAME_BAI}"
       re-save-file sj "${MATE1_NAME}_SJ.out.tab"
       re-save-file stats "${MATE1_NAME}_stats.txt"
       re-save species {{genome.species}}

--- a/resolwe_bio/tests/processes/test_alignment.py
+++ b/resolwe_bio/tests/processes/test_alignment.py
@@ -163,18 +163,40 @@ class AlignmentProcessorTestCase(KBBioProcessTestCase):
         self.assertFields(exp, 'build', 'GRCh38_ens90')
         self.assertFields(exp, 'feature_type', 'gene')
 
-        inputs = {
-            'genome': star_index_wo_annot.id,
-            'reads': reads.id,
-            'annotation': annotation.id,
-            't_coordinates': {
-                'quantmode': True,
-                'gene_counts': True,
-            },
-            'two_pass_mapping': {
-                'two_pass_mode': True,
-            },
-        }
+        inputs['star_sort'] = True
+        aligned_reads = self.run_process('alignment-star', inputs)
+        for data in Data.objects.all():
+            self.assertStatus(data, Data.STATUS_DONE)
+
+        self.assertFile(aligned_reads, 'gene_counts', 'gene_counts_star_single.tab.gz', compression='gzip')
+        self.assertFields(aligned_reads, 'species', 'Homo sapiens')
+        self.assertFields(aligned_reads, 'build', 'GRCh38_ens90')
+
+        exp = Data.objects.last()
+        self.assertFile(exp, 'exp', 'star_expression_single.tab.gz', compression='gzip')
+        self.assertFields(exp, 'source', 'ENSEMBL')
+        self.assertFields(exp, 'species', 'Homo sapiens')
+        self.assertFields(exp, 'build', 'GRCh38_ens90')
+        self.assertFields(exp, 'feature_type', 'gene')
+
+        inputs['genome'] = star_index_wo_annot.id
+        inputs['annotation'] = annotation.id
+        aligned_reads = self.run_process('alignment-star', inputs)
+        for data in Data.objects.all():
+            self.assertStatus(data, Data.STATUS_DONE)
+
+        self.assertFile(aligned_reads, 'gene_counts', 'gene_counts_star_single.tab.gz', compression='gzip')
+        self.assertFields(aligned_reads, 'species', 'Homo sapiens')
+        self.assertFields(aligned_reads, 'build', 'GRCh38_ens90')
+
+        exp = Data.objects.last()
+        self.assertFile(exp, 'exp', 'star_expression_single.tab.gz', compression='gzip')
+        self.assertFields(exp, 'source', 'ENSEMBL')
+        self.assertFields(exp, 'species', 'Homo sapiens')
+        self.assertFields(exp, 'build', 'GRCh38_ens90')
+        self.assertFields(exp, 'feature_type', 'gene')
+
+        inputs['star_sort'] = False
         aligned_reads = self.run_process('alignment-star', inputs)
         for data in Data.objects.all():
             self.assertStatus(data, Data.STATUS_DONE)
@@ -200,7 +222,21 @@ class AlignmentProcessorTestCase(KBBioProcessTestCase):
             'two_pass_mapping': {
                 'two_pass_mode': True,
             },
+            'star_sort': True,
         }
+        aligned_reads = self.run_process('alignment-star', inputs)
+        self.assertFile(aligned_reads, 'bigwig', 'bigwig_star_ens_paired.bw')
+        for data in Data.objects.all():
+            self.assertStatus(data, Data.STATUS_DONE)
+
+        self.assertFile(aligned_reads, 'gene_counts', 'gene_counts_star_paired.tab.gz', compression='gzip')
+        exp = Data.objects.last()
+        self.assertFile(exp, 'exp', 'star_expression_paired.tab.gz', compression='gzip')
+        self.assertFields(exp, 'source', 'ENSEMBL')
+        self.assertFile(exp, 'exp_set', 'star_out_exp_set.txt.gz', compression='gzip')
+        self.assertJSON(exp, exp.output['exp_set_json'], '', 'star_exp_set.json.gz')
+
+        inputs['star_sort'] = False
         aligned_reads = self.run_process('alignment-star', inputs)
         self.assertFile(aligned_reads, 'bigwig', 'bigwig_star_ens_paired.bw')
         for data in Data.objects.all():


### PR DESCRIPTION
## Checklist
* [x] Update CHANGELOG.rst for each commit separately:
  * Pay attention to write entries under the "Unreleased" section.
  * Mark all breaking changes as "**BACKWARD INCOMPATIBLE:**" and put them
    before non-breaking changes.
  * If a commit modifies a feature listed under "Unreleased" section,
    it might be sufficient to modify the existing CHANGELOG entry from previous
    commit(s).
* [x] Bump the process version:
  * **MAJOR version (first number)**: Backward incompatible changes (changes
    that break the api/interface). Examples: renaming the input/output, adding
    mandatory input, removing input/output...
  * **MINOR version (middle number)**: add functionality or changes in a
    backwards-compatible manner. Examples: add output field, add non-mandatory
    input parameter, use a different tool that produces same results...
  * **PATCH version (last number)**: changes/bug fixes that do not affect
    the api/interface. Examples: typo fix, change/add warning messages...
* [x] All inputs are used in process.
* [x] All output fields have their ``re-save`` calls.

### Description ###
When comparing sorting with STAR and sorting with samtools, we concluded that sorting with samtools is less memory intensive and faster on a HDD. The sorted alignments (outputs) were tested with deepTools for coverage, quantified using fetureCounts and viewed with IGV. In all test we did not observe any difference, between the alignements sorted with STAR or samtools.
I added an option for selecting the sorting process (samtools or STAR), with the default being samtools. I run tests once with samtools sorting and once with STAR sorting. Both tests produced no errors.


