### PR TITLE
Make bigwig field not mandatory for bamclipper, bqsr and markduplicates

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -14,6 +14,8 @@ Changed
 -------
 - Append sample and genome reference information to the summary output
   file in the ``filtering-chemut`` process
+- Bigwig output field in ``bamclipper``, ``bqsr`` and ``markduplicates``
+  processes is no longer required
 
 
 ===================

--- a/resolwe_bio/processes/reads_processing/bamclipper.py
+++ b/resolwe_bio/processes/reads_processing/bamclipper.py
@@ -8,13 +8,14 @@ from shutil import copy2
 class Bamclipper(Process):
     """Remove primer sequence from BAM alignments by soft-clipping.
 
-    This process is a wrapper for bamclipper which can be found at https://github.com/tommyau/bamclipper.
+    This process is a wrapper for bamclipper which can be found at
+    https://github.com/tommyau/bamclipper.
     """
 
     slug = 'bamclipper'
     name = 'Bamclipper'
     process_type = 'data:alignment:bam:bamclipped:'
-    version = '1.1.0'
+    version = '1.1.1'
     category = 'Clipping'
     shaduling_class = SchedulingClass.BATCH
     entity = {'type': 'sample'}
@@ -45,7 +46,7 @@ class Bamclipper(Process):
         bam = FileField(label='Clipped BAM file')
         bai = FileField(label='Index of clipped BAM file')
         stats = FileField(label='Alignment statistics')
-        bigwig = FileField(label='BigWig file')
+        bigwig = FileField(label='BigWig file', required=False)
         species = StringField(label='Species')
         build = StringField(label='Build')
 
@@ -134,12 +135,14 @@ class Bamclipper(Process):
             self.info(
                 'BigWig file not calculated.'
             )
+        else:
+            outputs.bigwig = bigwig
 
         self.progress(0.9)
 
         outputs.bam = bam
         outputs.bai = bai
         outputs.stats = stats
-        outputs.bigwig = bigwig
+
         outputs.species = bam_species
         outputs.build = bam_build

--- a/resolwe_bio/processes/reads_processing/bqsr.py
+++ b/resolwe_bio/processes/reads_processing/bqsr.py
@@ -18,7 +18,7 @@ class BQSR(Process):
     slug = 'bqsr'
     name = 'BaseQualityScoreRecalibrator'
     process_type = 'data:alignment:bam:bqsr:'
-    version = '1.1.0'
+    version = '1.1.1'
     category = 'BAM processing'
     shaduling_class = SchedulingClass.BATCH
     entity = {'type': 'sample'}
@@ -82,7 +82,7 @@ class BQSR(Process):
         bam = FileField(label='Base quality score recalibrated BAM file')
         bai = FileField(label='Index of base quality score recalibrated BAM file')
         stats = FileField(label='Alignment statistics')
-        bigwig = FileField(label='BigWig file')
+        bigwig = FileField(label='BigWig file', required=False)
         species = StringField(label='Species')
         build = StringField(label='Build')
         recal_table = FileField(label='Recalibration tabled')
@@ -173,17 +173,20 @@ class BQSR(Process):
 
         Cmd['bamtobigwig.sh'](btb_inputs)
 
-        if not os.path.exists(f'{file_name}.bw'):
+        bigwig = file_name + '.bw'
+        if not os.path.exists(bigwig):
             self.info(
                 'BigWig file not calculated.'
             )
+        else:
+            outputs.bigwig = bigwig
 
         self.progress(0.9)
 
         outputs.bam = bam
         outputs.bai = file_name + '.bai'
         outputs.stats = stats
-        outputs.bigwig = file_name + '.bw'
+
         outputs.species = species
         outputs.build = inputs.bam.build
         outputs.recal_table = recal_table

--- a/resolwe_bio/processes/reads_processing/markduplicates.py
+++ b/resolwe_bio/processes/reads_processing/markduplicates.py
@@ -15,7 +15,7 @@ class MarkDuplicates(Process):
     slug = 'markduplicates'
     name = 'MarkDuplicates'
     process_type = 'data:alignment:bam:markduplicate:'
-    version = '1.1.0'
+    version = '1.1.1'
     category = 'BAM processing'
     shaduling_class = SchedulingClass.BATCH
     entity = {'type': 'sample'}
@@ -81,7 +81,7 @@ class MarkDuplicates(Process):
         bam = FileField(label='Marked duplicates BAM file')
         bai = FileField(label='Index of marked duplicates BAM file')
         stats = FileField(label='Alignment statistics')
-        bigwig = FileField(label='BigWig file')
+        bigwig = FileField(label='BigWig file', required=False)
         species = StringField(label='Species')
         build = StringField(label='Build')
         metrics_file = FileField(label='Metrics from MarkDuplicate process')
@@ -167,17 +167,20 @@ class MarkDuplicates(Process):
 
         Cmd['bamtobigwig.sh'](btb_inputs)
 
-        if not os.path.exists(f'{file_name}.bw'):
+        bigwig = bam[:-4] + '.bw'
+        if not os.path.exists(bigwig):
             self.info(
                 'BigWig file not calculated.'
             )
+        else:
+            outputs.bigwig = bigwig
 
         self.progress(0.9)
 
         outputs.bam = bam
         outputs.bai = bam + '.bai'
         outputs.stats = stats
-        outputs.bigwig = bam[:-4] + '.bw'
+
         outputs.species = species
         outputs.build = build
         outputs.metrics_file = metrics_file

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setuptools.setup(
             # work with our custom page template.
             'Sphinx~=1.5.6',
             'sphinx_rtd_theme',
+            'docutils==0.15.2',
         ],
         'package': ['twine', 'wheel'],
         'test': [


### PR DESCRIPTION
Cases, where bigwig file was not calculated, stopped. This PR makes the output field of bigwig not required and should solve this problem.

Sphinx is having problems parsing docstrings so we're freezing the docutils to version 0.15.2.

## Checklist
<!--
Mark an `[x]` for completed items.
-->

* [x] Update CHANGELOG.rst for each commit separately:
  * Pay attention to write entries under the "Unreleased" section.
  * Mark all breaking changes as "**BACKWARD INCOMPATIBLE:**" and put them
    before non-breaking changes.
  * If a commit modifies a feature listed under "Unreleased" section,
    it might be sufficient to modify the existing CHANGELOG entry from previous
    commit(s).
* [x] Bump the process version:
  * **MAJOR version (first number)**: Backward incompatible changes (changes
    that break the api/interface). Examples: renaming the input/output, adding
    mandatory input, removing input/output...
  * **MINOR version (middle number)**: add functionality or changes in a
    backwards-compatible manner. Examples: add output field, add non-mandatory
    input parameter, use a different tool that produces same results...
  * **PATCH version (last number)**: changes/bug fixes that do not affect
    the api/interface. Examples: typo fix, change/add warning messages...
* [x] All inputs are used in process.
* [x] All output fields have their ``re-save`` calls.
