### PR TITLE
Explain why docutils has been frozen to 0.15.2

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -16,7 +16,8 @@ Changed
   file in the ``filtering-chemut`` process
 - Bigwig output field in ``bamclipper``, ``bqsr`` and ``markduplicates``
   processes is no longer required
-
+- Freeze docutils package version to 0.15.2 because Sphinx has
+  problems parsing development version numbers
 
 ===================
 24.0.0 - 2019-11-15

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,8 @@ setuptools.setup(
             # work with our custom page template.
             'Sphinx~=1.5.6',
             'sphinx_rtd_theme',
+            # XXX: Temporarily freeze docutils to 0.15.2 since Sphinx has
+            # problems parsing dev version (0.16b).
             'docutils==0.15.2',
         ],
         'package': ['twine', 'wheel'],


### PR DESCRIPTION
Sphinx has problems parsing the dev version of `docutils` (0.16b.0). For the time being, we are freezing the version to 0.15.2.

* [x] Update CHANGELOG.rst for each commit separately:
  * Pay attention to write entries under the "Unreleased" section.
  * Mark all breaking changes as "**BACKWARD INCOMPATIBLE:**" and put them
    before non-breaking changes.
  * If a commit modifies a feature listed under "Unreleased" section,
    it might be sufficient to modify the existing CHANGELOG entry from previous
    commit(s).
* [x] Bump the process version:
  * **MAJOR version (first number)**: Backward incompatible changes (changes
    that break the api/interface). Examples: renaming the input/output, adding
    mandatory input, removing input/output...
  * **MINOR version (middle number)**: add functionality or changes in a
    backwards-compatible manner. Examples: add output field, add non-mandatory
    input parameter, use a different tool that produces same results...
  * **PATCH version (last number)**: changes/bug fixes that do not affect
    the api/interface. Examples: typo fix, change/add warning messages...
* [x] All inputs are used in process.
* [x] All output fields have their ``re-save`` calls.
