### PR TITLE
Handle improper read_group tags in bqsr process

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -18,6 +18,8 @@ Changed
 Fixed
 -----
 - Fix typo in ``scheduling_class`` variable in several Python processes
+- Handle cases of improper tags passed to ``read_group`` argument of
+  the ``bqsr`` process
 
 
 ===================

--- a/resolwe_bio/processes/reads_processing/bqsr.py
+++ b/resolwe_bio/processes/reads_processing/bqsr.py
@@ -18,7 +18,7 @@ class BQSR(Process):
     slug = 'bqsr'
     name = 'BaseQualityScoreRecalibrator'
     process_type = 'data:alignment:bam:bqsr:'
-    version = '1.1.2'
+    version = '1.2.0'
     category = 'BAM processing'
     scheduling_class = SchedulingClass.BATCH
     entity = {'type': 'sample'}
@@ -114,16 +114,23 @@ class BQSR(Process):
                 arrg.extend(split_tag)
                 present_tags.append(split_tag[0])
 
-            # Check that there are no double entries of tags.
+            # Make sure all arguments to read_group are valid.
+            all_tags = {'-LB', '-PL', '-PU', '-SM', '-CN', '-DS', '-DT', '-FO',
+                        '-ID', '-KS', '-PG', '-PI', '-PM', '-SO'}
             present_tag_set = set(present_tags)
+            check_all_tags = present_tag_set.issubset(all_tags)
+            if not check_all_tags:
+                self.error('One or more read_group argument(s) improperly formatted.')
+
+            # Check that there are no double entries of arguments to read_group.
             if len(present_tag_set) != len(present_tags):
                 self.error('You have duplicate tags in read_group argument.')
 
-            # This gracefully checks that all mandatory variables are present.
+            # Check that all mandatory arguments to read_group are present.
             mandatory_tags = {'-LB', '-PL', '-PU', '-SM'}
             check_tags = mandatory_tags.issubset(present_tag_set)
             if not check_tags:
-                self.error(f'Missing mandatory read_group argument (-PL, -LB, -PU and -SM are mandatory).')
+                self.error('Missing mandatory read_group argument(s) (-PL, -LB, -PU and -SM are mandatory).')
 
             Cmd['gatk']['AddOrReplaceReadGroups'](arrg)
         else:

--- a/resolwe_bio/tests/processes/test_reads_filtering.py
+++ b/resolwe_bio/tests/processes/test_reads_filtering.py
@@ -406,3 +406,10 @@ class ReadsFilteringProcessorTestCase(BioProcessTestCase):
             bqsr_inputs['read_group'] = '-LB=DAB;-PL=Illumina;-PU=barcode;-SM=sample1;-SM=sample2'
             bqsr_dbltag = self.run_process('bqsr', bqsr_inputs, Data.STATUS_ERROR)
             self.assertEqual(bqsr_dbltag.process_error[0], 'You have duplicate tags in read_group argument.')
+
+            bqsr_inputs['read_group'] = 'LB=DAB;-PL=Illumina;-PU=barcode;-SM=sample1'  # missing dash in LB
+            bqsr_tagerror = self.run_process('bqsr', bqsr_inputs, Data.STATUS_ERROR)
+            self.assertEqual(
+                bqsr_tagerror.process_error[0],
+                'One or more read_group argument(s) improperly formatted.'
+            )


### PR DESCRIPTION
A user might have incorrectly specify tag of the `read_group` argument. This PR checks that all inputs have the `-XX` structure.
Checks now goes from broad to specific, i.e. first it makes sure all tags exist/are correctly entered, there are no duplicates and finally if mandatory tags are used.

## Checklist
* [x] Update CHANGELOG.rst for each commit separately:
  * Pay attention to write entries under the "Unreleased" section.
  * Mark all breaking changes as "**BACKWARD INCOMPATIBLE:**" and put them
    before non-breaking changes.
  * If a commit modifies a feature listed under "Unreleased" section,
    it might be sufficient to modify the existing CHANGELOG entry from previous
    commit(s).
* [x] Bump the process version:
  * **MAJOR version (first number)**: Backward incompatible changes (changes
    that break the api/interface). Examples: renaming the input/output, adding
    mandatory input, removing input/output...
  * **MINOR version (middle number)**: add functionality or changes in a
    backwards-compatible manner. Examples: add output field, add non-mandatory
    input parameter, use a different tool that produces same results...
  * **PATCH version (last number)**: changes/bug fixes that do not affect
    the api/interface. Examples: typo fix, change/add warning messages...
* [x] All inputs are used in process.
* [x] All output fields have their ``re-save`` calls.