### PR TITLE
Fix typo in scheduling_class parameter in several Python processes

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -5,6 +5,20 @@ Change Log
 All notable changes to this project are documented in this file.
 This project adheres to `Semantic Versioning <http://semver.org/>`_.
 
+==========
+Unreleased
+==========
+
+Added
+-----
+
+Changed
+-------
+
+Fixed
+-----
+- Fix typo in ``scheduling_class`` variable in several Python processes
+
 
 ===================
 25.0.0 - 2019-12-17

--- a/resolwe_bio/processes/differential_expression/shRNAde.py
+++ b/resolwe_bio/processes/differential_expression/shRNAde.py
@@ -29,9 +29,9 @@ class ShortHairpinRNADifferentialExpression(Process):
     slug = 'differentialexpression-shrna'
     name = 'Differential expression of shRNA'
     process_type = 'data:shrna:differentialexpression:'
-    version = '1.0.0'
+    version = '1.0.1'
     category = 'Differential Expression'
-    shaduling_class = SchedulingClass.BATCH
+    scheduling_class = SchedulingClass.BATCH
     entity = {'type': 'sample'}
     requirements = {
         'expression-engine': 'jinja',

--- a/resolwe_bio/processes/import_data/bam_scseq.py
+++ b/resolwe_bio/processes/import_data/bam_scseq.py
@@ -18,9 +18,9 @@ class ImportScBam(Process):
     slug = 'upload-bam-scseq-indexed'
     name = 'Single cell BAM file and index'
     process_type = 'data:alignment:bam:scseq'
-    version = '1.0.0'
+    version = '1.0.1'
     category = 'Import'
-    sheduling_class = SchedulingClass.BATCH
+    scheduling_class = SchedulingClass.BATCH
     entity = {
         'type': 'sample'
     }

--- a/resolwe_bio/processes/import_data/seq_reads_10x.py
+++ b/resolwe_bio/processes/import_data/seq_reads_10x.py
@@ -19,9 +19,9 @@ class ImportScRNA10x(Process):
     slug = 'upload-sc-10x'
     name = 'Reads (scRNA 10x)'
     process_type = 'data:screads:10x:'
-    version = '1.1.0'
+    version = '1.1.1'
     category = 'Import'
-    sheduling_class = SchedulingClass.BATCH
+    scheduling_class = SchedulingClass.BATCH
     entity = {
         'type': 'sample',
         'descriptor_schema': 'sample',

--- a/resolwe_bio/processes/reads_processing/bamclipper.py
+++ b/resolwe_bio/processes/reads_processing/bamclipper.py
@@ -15,9 +15,9 @@ class Bamclipper(Process):
     slug = 'bamclipper'
     name = 'Bamclipper'
     process_type = 'data:alignment:bam:bamclipped:'
-    version = '1.1.1'
+    version = '1.1.2'
     category = 'Clipping'
-    shaduling_class = SchedulingClass.BATCH
+    scheduling_class = SchedulingClass.BATCH
     entity = {'type': 'sample'}
     requirements = {
         'expression-engine': 'jinja',

--- a/resolwe_bio/processes/reads_processing/bqsr.py
+++ b/resolwe_bio/processes/reads_processing/bqsr.py
@@ -18,9 +18,9 @@ class BQSR(Process):
     slug = 'bqsr'
     name = 'BaseQualityScoreRecalibrator'
     process_type = 'data:alignment:bam:bqsr:'
-    version = '1.1.1'
+    version = '1.1.2'
     category = 'BAM processing'
-    shaduling_class = SchedulingClass.BATCH
+    scheduling_class = SchedulingClass.BATCH
     entity = {'type': 'sample'}
     requirements = {
         'expression-engine': 'jinja',

--- a/resolwe_bio/processes/reads_processing/cutadapt_3prime.py
+++ b/resolwe_bio/processes/reads_processing/cutadapt_3prime.py
@@ -23,9 +23,9 @@ class Cutadapt3Prime(Process):
     slug = 'cutadapt-3prime-single'
     name = "Cutadapt (3' mRNA-seq, single-end)"
     process_type = 'data:reads:fastq:single:cutadapt:'
-    version = '1.0.1'
+    version = '1.0.2'
     category = 'Other'
-    shaduling_class = SchedulingClass.BATCH
+    scheduling_class = SchedulingClass.BATCH
     entity = {'type': 'sample'}
     requirements = {
         'expression-engine': 'jinja',

--- a/resolwe_bio/processes/reads_processing/cutadapt_corall.py
+++ b/resolwe_bio/processes/reads_processing/cutadapt_corall.py
@@ -26,9 +26,9 @@ class CutadaptCorallSingle(Process):
     slug = 'cutadapt-corall-single'
     name = "Cutadapt (Corall RNA-Seq, single-end)"
     process_type = 'data:reads:fastq:single:cutadapt:'
-    version = '1.0.1'
+    version = '1.0.2'
     category = 'Other'
-    shaduling_class = SchedulingClass.BATCH
+    scheduling_class = SchedulingClass.BATCH
     entity = {'type': 'sample'}
     requirements = {
         'expression-engine': 'jinja',
@@ -171,9 +171,9 @@ class CutadaptCorallPaired(Process):
     slug = 'cutadapt-corall-paired'
     name = "Cutadapt (Corall RNA-Seq, paired-end)"
     process_type = 'data:reads:fastq:paired:cutadapt:'
-    version = '1.0.1'
+    version = '1.0.2'
     category = 'Other'
-    shaduling_class = SchedulingClass.BATCH
+    scheduling_class = SchedulingClass.BATCH
     entity = {'type': 'sample'}
     requirements = {
         'expression-engine': 'jinja',

--- a/resolwe_bio/processes/reads_processing/markduplicates.py
+++ b/resolwe_bio/processes/reads_processing/markduplicates.py
@@ -15,9 +15,9 @@ class MarkDuplicates(Process):
     slug = 'markduplicates'
     name = 'MarkDuplicates'
     process_type = 'data:alignment:bam:markduplicate:'
-    version = '1.1.1'
+    version = '1.1.2'
     category = 'BAM processing'
-    shaduling_class = SchedulingClass.BATCH
+    scheduling_class = SchedulingClass.BATCH
     entity = {'type': 'sample'}
     requirements = {
         'expression-engine': 'jinja',

--- a/resolwe_bio/processes/scseq/cellranger.py
+++ b/resolwe_bio/processes/scseq/cellranger.py
@@ -28,9 +28,9 @@ class CellRangerMkref(Process):
     slug = 'cellranger-mkref'
     name = 'Cell Ranger Mkref'
     process_type = 'data:genomeindex:10x'
-    version = '1.0.2'
+    version = '1.0.3'
     category = 'scRNA-Seq'
-    sheduling_class = SchedulingClass.BATCH
+    scheduling_class = SchedulingClass.BATCH
     requirements = {
         'expression-engine': 'jinja',
         'executor': {
@@ -113,9 +113,9 @@ class CellRangerCount(Process):
     slug = 'cellranger-count'
     name = 'Cell Ranger Count'
     process_type = 'data:scexpression:10x'
-    version = '1.0.3'
+    version = '1.0.4'
     category = 'scRNA-Seq'
-    sheduling_class = SchedulingClass.BATCH
+    scheduling_class = SchedulingClass.BATCH
     entity = {
         'type': 'sample'
     }


### PR DESCRIPTION
Noticed a typo that has been disseminated through a few processes possibly due to copy/pasting.

## Checklist
* [X] Update CHANGELOG.rst for each commit separately:
  * Pay attention to write entries under the "Unreleased" section.
  * Mark all breaking changes as "**BACKWARD INCOMPATIBLE:**" and put them
    before non-breaking changes.
  * If a commit modifies a feature listed under "Unreleased" section,
    it might be sufficient to modify the existing CHANGELOG entry from previous
    commit(s).
* [X] Bump the process version:
  * **MAJOR version (first number)**: Backward incompatible changes (changes
    that break the api/interface). Examples: renaming the input/output, adding
    mandatory input, removing input/output...
  * **MINOR version (middle number)**: add functionality or changes in a
    backwards-compatible manner. Examples: add output field, add non-mandatory
    input parameter, use a different tool that produces same results...
  * **PATCH version (last number)**: changes/bug fixes that do not affect
    the api/interface. Examples: typo fix, change/add warning messages...
* [X] All inputs are used in process.
* [X] All output fields have their ``re-save`` calls.
