### PR TITLE
Fix Mapping search for source_id / target_id

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -44,6 +44,10 @@ Changed
   ``clustering-hierarchical-genes``, ``import-sra``,
   ``import-sra-single``, ``import-sra-paired``.
 
+Fixed
+-----
+- Fix Mapping search for ``source_id`` / ``target_id``
+
 
 ===================
 25.1.0 - 2020-01-14

--- a/resolwe_bio/kb/tests/test_mapping.py
+++ b/resolwe_bio/kb/tests/test_mapping.py
@@ -56,7 +56,7 @@ class MappingTestCase(APITestCase, ElasticSearchTestCase):
         response = self.client.post(MAPPING_URL, {
             'source_db': 'SRC',
             'target_db': 'TGT',
-            'source_id': ['FT0', 'FT1', 'FT5']
+            'source_id__in': 'FT0,FT1,FT5'
         }, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 3)
@@ -68,7 +68,7 @@ class MappingTestCase(APITestCase, ElasticSearchTestCase):
         response = self.client.post(MAPPING_URL, {
             'source_db': 'SRC',
             'target_db': 'TGT',
-            'source_id': [str(x) for x in range(2048)]
+            'source_id__in': ','.join([str(x) for x in range(512)])
         }, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 

--- a/resolwe_bio/kb/views.py
+++ b/resolwe_bio/kb/views.py
@@ -156,34 +156,17 @@ class MappingSearchViewSet(ElasticSearchBaseViewSet):
     document_class = MappingSearchDocument
     serializer_class = MappingSerializer
 
-    filtering_fields = ('source_db', 'source_species', 'target_db', 'target_species', 'relation_type')
+    filtering_fields = (
+        'relation_type',
+        'source_db',
+        'source_id',
+        'source_species',
+        'target_db',
+        'target_id',
+        'target_species',
+    )
     ordering_fields = ('source_id',)
     ordering = 'source_id'
-
-    def get_always_allowed_arguments(self):
-        """Return query arguments which are always allowed."""
-        return super().get_always_allowed_arguments() + [
-            'source_id',
-            'target_id',
-        ]
-
-    def custom_filter(self, search):
-        """Support correct searching by ``source_id`` and ``target_id``."""
-        for field in ('source_id', 'target_id'):
-            query = self.get_query_param(field, None)
-            if not query:
-                continue
-            if not isinstance(query, list):
-                query = [query]
-
-            search = search.filter(
-                'bool',
-                should=[
-                    Q('terms', **{field: query}),
-                ]
-            )
-
-        return search
 
     def filter_permissions(self, search):
         """Filter permissions since Mapping objects have no permissions."""


### PR DESCRIPTION
If one did a Mappings query with multiple source_id/target_id as
query parameter the response would be empty or Error. There are
multiple options for one to get multiple Mappings from api. These
are the actual query parameters in request URL:

1. source_id="ID1,ID2"
2. source_id=["ID1", "ID2"]
3. source_id__in="ID1,ID2"
4. source_id__in=["ID1", "ID2"]

The main point is that value of query parameter must be casted to
list as some point. Since source_id is a custom filter the "__in"
snytax is not allowed (3. and 4. are not an option) but there is
no place in code where 1. and 2. would be casted to list. Therefore
the result of 1. or 2 was empty and 3. or 4. raised error.

This solution removes source_id (and targed_id) as custom filters
and places them as normal filtering parameters. Therefore "__in"
syntax is supported and the value of query parameter is splitted by
commma and casted to list. This is also sonsistent with how Feature
filter works for feature_id.

The regression of this solution is is the size of the list that can
be handled by ES in such cases. It reduces to 512 (not exact, but
1024 fails) by unknown reasons(ideas anyone?). However, in practice
this means that before one could filter by max 1 source_id and now
the limit is 512, which seems way better.

## Checklist
<!--
Mark an `[x]` for completed items.
-->

* [ ] Update CHANGELOG.rst for each commit separately:
  * Pay attention to write entries under the "Unreleased" section.
  * Mark all breaking changes as "**BACKWARD INCOMPATIBLE:**" and put them
    before non-breaking changes.
  * If a commit modifies a feature listed under "Unreleased" section,
    it might be sufficient to modify the existing CHANGELOG entry from previous
    commit(s).
* [ ] Bump the process version:
  * **MAJOR version (first number)**: Backward incompatible changes (changes
    that break the api/interface). Examples: renaming the input/output, adding
    mandatory input, removing input/output...
  * **MINOR version (middle number)**: add functionality or changes in a
    backwards-compatible manner. Examples: add output field, add non-mandatory
    input parameter, use a different tool that produces same results...
  * **PATCH version (last number)**: changes/bug fixes that do not affect
    the api/interface. Examples: typo fix, change/add warning messages...
* [ ] All inputs are used in process.
* [ ] All output fields have their ``re-save`` calls.

<!--
Read the following guidelines and remove them before opening the pull request.
-->

## Additional guidelines

### Processes ###

* Code that was once accepted should be kept like it is. It should be changed
  only when its functionality has changed. Small parts may be changed
  to fix bugs (by changing code only to make it nicer you might introduce a bug).
* Set the optimal number of cores that the tool can use (check if parallelization
  can be performed).
* Description of tool should be self explanatory with links to tool's homepage
  and publication.
* Write explanatory input labels and add short command line parameter names
  in square brackets (for example: Maximum length [``--maxlength``]).
* Where possible provide default values for the process input fields.
  If they are provided, then ``required: false`` is not needed.
* Add descriptive error and warning messages.
* Place a ``re-checkrc`` call after each process step (call of a tool, a
  Bash command, a Python script or an R script).
* Add ``re-progress`` calls where appropriate.

### Commit and PR messages ###

* Each commit should be minimal (i.e. 1 change) and self-contained (including
  tests).
* Changes to Docker images need to be accepted in a separate pull request.
  Before the new images can be used for automated testing of your PR, they
  must be manually tagged and pushed to Docker Hub.
* Mark incomplete PRs with the [WIP] (Work In Progress) tag.
* Do not paste links to private repositories from the public one.

### Tests ###

* Add meaningful names of test files with spaces:
  * Genomes: ``genome species.fa.gz``
  * Annotations: ``annotation species.gtf.gz``
  * Adapters: ``adapters-name/type-source``.
* Output and specific input files should include the name of the tested tool.
* Keep test files' size small. If there is no other option, add the large
  test file to the ``files/large`` directory so it will be tracked with Git LFS.
* Pay attention to edge cases: what will happen if any data is
  missing, if length of some list is 0, if string is given where one expects
  integer, if file is empty, ...
* When testing workflows, try to verify workflow success by checking one
  of the last steps. Pick the one that is most likely to fail. Also test
  that all steps have 'OK' status.

<!--
Thanks!
-->
