### PR TITLE
Add Read the Docs configuration file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ sftp-config.json
 !.env
 !.scripts/
 !.placeholder
+!.readthedocs.yml
 !.resolwebio-filetypes.yml
 
 # Ignore backup files

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,17 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+version: 2
+
+sphinx:
+  configuration: docs/conf.py
+
+formats: all
+
+python:
+  version: 3.7
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+          - docs

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@
 include LICENSE
 # Include documentation and files needed by documentation.
 recursive-include docs *.py *.rst *.css *.html
+include .readthedocs.yml
 # Include tests and files needed by tests (except large files).
 include tox.ini
 include pyproject.toml


### PR DESCRIPTION
Solves the issue with Read the Docs documentation failing. During the documentation build, instead of specified pyasn1 package, pyasn1-modules is selected instead. As a consequence, pyasn1 package is missing.

We switch to [Read the Docs configuration file](https://docs.readthedocs.io/en/stable/config-file/v2.html) to work around this issue.