### PR TITLE
Increase jenkins timeout to 90 minutes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ throttle(["resolwe_bio"]) {
 
         // NOTE: Tests could hang unexpectedly and never release the Jenkins executor. Thus we set
         // a general timeout for tests' execution.
-        timeout(time: 60, unit: "MINUTES") {
+        timeout(time: 90, unit: "MINUTES") {
 
             try {
                 stage("Checkout") {


### PR DESCRIPTION
Current timeout in Jenkinsfile is set to 60 minutes, which is too short and many processes get killed. Timeout is increased to 90 minutes.