### PR TITLE
Fix tox testenv

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ basepython = python3
 
 [testenv]
 basepython =
-    py36, docs, linters, packaging, extra, migrations: python3.6
+    py36,docs,linters,packaging,extra,migrations: python3.6
     py37: python3.7
     py38: python3.8
 extras =


### PR DESCRIPTION
When tests are run, most of the steps are skipped, because tox does not support spaces in environment definitions.

Changes:
- Change definition for basepython builds in tox.ini