### PR TITLE
Handle empty input in BED file correction script

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -25,7 +25,7 @@ Add
 Changed
 -------
 - **BACKWARD INCOMPATIBLE:** Require Resolwe 21.x
-- **BACKWARD INCOMPATIBLE:** Split ``wgbs`` workflow into 
+- **BACKWARD INCOMPATIBLE:** Split ``wgbs`` workflow into
   ``wgbs-single`` and ``wgbs-paired``
 - Use human samples for ``alignment-star`` testing
 - Bump memory requirements in ``rrbs-metrics`` process
@@ -44,6 +44,8 @@ Fixed
   were created for some inputs.
 - Fix ``macs2-callpeak`` process to work with paired-end reads when
   not using tagAlign files
+- Fix ``bed_file_corrections_genome_browsers.py`` script to handle cases
+  where the input file is empty
 
 Added
 -----

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -9,8 +9,8 @@ This project adheres to `Semantic Versioning <http://semver.org/>`_.
 Unreleased
 ==========
 
-Add
----
+Added
+-----
 - Add ``merge-fastq-single`` and ``merge-fastq-paired`` processes that
   merge multiple ``data:reads:fastq``` data objects into a single
   ``data:reads:fastq`` data object (and consequently a single sample)
@@ -21,6 +21,7 @@ Add
 - Enable separation of unmethylated control reads from others in
   ``walt`` process
 - Add ``bs-conversion-rate`` process
+- Add support for Python 3.8
 
 Changed
 -------
@@ -47,9 +48,6 @@ Fixed
 - Fix ``bed_file_corrections_genome_browsers.py`` script to handle cases
   where the input file is empty
 
-Added
------
-- Add support for Python 3.8
 
 ===================
 26.0.0 - 2020-02-14

--- a/resolwe_bio/processes/chip_seq/macs14.yml
+++ b/resolwe_bio/processes/chip_seq/macs14.yml
@@ -11,7 +11,7 @@
       docker:
         image: resolwebio/chipseq:4.0.0
   data_name: "MACS results ({{ treatment|sample_name|default('?') }})"
-  version: 3.2.1
+  version: 3.2.2
   type: data:chipseq:callpeak:macs14
   entity:
     type: sample

--- a/resolwe_bio/processes/chip_seq/macs2.yml
+++ b/resolwe_bio/processes/chip_seq/macs2.yml
@@ -14,7 +14,7 @@
       memory: 16384
       cores: 10
   data_name: "{{ case|sample_name|default('?') }}"
-  version: 4.0.7
+  version: 4.0.8
   type: data:chipseq:callpeak:macs2
   entity:
     type: sample

--- a/resolwe_bio/processes/junctions/regtools.yml
+++ b/resolwe_bio/processes/junctions/regtools.yml
@@ -9,7 +9,7 @@
     {{ alignment_star|sample_name|default('') }}
     {{ alignment|sample_name|default('') }}
     {{ input_bed_junctions.bed.file|default('') }}
-  version: 0.3.0
+  version: 0.3.1
   type: data:junctions:regtools
   requirements:
     expression-engine: jinja

--- a/resolwe_bio/tools/bed_file_corrections_genome_browsers.py
+++ b/resolwe_bio/tools/bed_file_corrections_genome_browsers.py
@@ -9,17 +9,27 @@ Correct bed file to be compatible with bedToBigBed tool.
 import argparse
 import pandas as pd
 
+from pandas.errors import EmptyDataError
+from resolwe_runtime_utils import error
+
 parser = argparse.ArgumentParser(description=__doc__)
 parser.add_argument('-f', '--bed_file', help="Bed file.")
 args = parser.parse_args()
 
-df = pd.read_csv(args.bed_file, delimiter='\t', header=None, dtype=str)
-df.iloc[:, 4] = pd.to_numeric(df.iloc[:, 4]).round().astype(int)
-df.iloc[:, 4] = df.iloc[:, 4].clip(upper=1000)
+try:
+    df = pd.read_csv(args.bed_file, delimiter='\t', header=None, dtype=str)
+except EmptyDataError:
+    print(error(
+        f'The input BED file {args.bed_file} is empty. Your analysis might '
+        f'have failed to identify regions of interest (peaks, junctions, etc.).'
+    ))
+else:
+    df.iloc[:, 4] = pd.to_numeric(df.iloc[:, 4]).round().astype(int)
+    df.iloc[:, 4] = df.iloc[:, 4].clip(upper=1000)
 
-# if strand column exist replace '?' with '.'
-if len(df.columns) >= 6:
-    df.iloc[:, 5] = df.iloc[:, 5].replace('?', '.')
+    # if strand column exist replace '?' with '.'
+    if len(df.columns) >= 6:
+        df.iloc[:, 5] = df.iloc[:, 5].replace('?', '.')
 
-output_name = '_'.join(['corrected', args.bed_file])
-df.to_csv(output_name, sep='\t', index=False, header=False)
+    output_name = '_'.join(['corrected', args.bed_file])
+    df.to_csv(output_name, sep='\t', index=False, header=False)


### PR DESCRIPTION
For some samples, the MACS analysis fails to identify peaks and thus produces an empty .narrowpeaks file. In such cases, Pandas `EmptyDataError` occurs. With this fix, we can detect such events and fail the process with a more user-friendly error message.