### PR TITLE
Add two extra parameters to bamtobigwig.sh script

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -5,6 +5,14 @@ Change Log
 All notable changes to this project are documented in this file.
 This project adheres to `Semantic Versioning <http://semver.org/>`_.
 
+==========
+Unreleased
+==========
+
+Added
+-------
+- Added parameters ``--normalizeUsing`` and ``--smoothLength`` to
+  script ``bamtobigwig.sh`` to be used in ``bamCoverage`` program
 
 ==========
 Unreleased


### PR DESCRIPTION
Two added parameters are `--normalizeUsing` and `--smoothLength` to be used in the bamCoverage program.

Since there's no explicit test for this process, I tried running all tests that I could find that check for `.bw` file (test_bwa, test_hisat2_bigwig...). They don't seem to produce any errors.


## Checklist

* [x] Update CHANGELOG.rst for each commit separately:
  * Pay attention to write entries under the "Unreleased" section.
  * Mark all breaking changes as "**BACKWARD INCOMPATIBLE:**" and put them
    before non-breaking changes.
  * If a commit modifies a feature listed under "Unreleased" section,
    it might be sufficient to modify the existing CHANGELOG entry from previous
    commit(s).
* [x] Bump the process version:
  * **MAJOR version (first number)**: Backward incompatible changes (changes
    that break the api/interface). Examples: renaming the input/output, adding
    mandatory input, removing input/output...
  * **MINOR version (middle number)**: add functionality or changes in a
    backwards-compatible manner. Examples: add output field, add non-mandatory
    input parameter, use a different tool that produces same results...
  * **PATCH version (last number)**: changes/bug fixes that do not affect
    the api/interface. Examples: typo fix, change/add warning messages...
* [x] All inputs are used in process.
* [x] All output fields have their ``re-save`` calls.
