### PR TITLE
Add Trim galore in resolwebio/rnaseq:4.12.0

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -16,7 +16,7 @@ Added
 - Added parameters ``--no-unal`` and ``--no-overlap`` to process
   ``alignment-bowtie``
 - Add ``alignmentsieve`` process
-
+- Add Trim Galore tool to ``resolwebio/rnaseq:4.12.0``
 
 Changed
 -------

--- a/resolwe_bio/docker_images/rnaseq/README.md
+++ b/resolwe_bio/docker_images/rnaseq/README.md
@@ -29,3 +29,4 @@ Included bioinformatics tools:
 * tximport (v1.12.3)
 * shRNAde (v1.0)
 * UMI-tools (v1.0.0)
+* Trim Galore (v0.6.6)

--- a/resolwe_bio/docker_images/rnaseq/packages-manual.txt
+++ b/resolwe_bio/docker_images/rnaseq/packages-manual.txt
@@ -11,3 +11,4 @@ rsem
 salmon
 star
 trimmomatic
+trimgalore

--- a/resolwe_bio/docker_images/rnaseq/packages-manual/trimgalore.sh
+++ b/resolwe_bio/docker_images/rnaseq/packages-manual/trimgalore.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -e
+
+. /var/cache/build/packages-manual/common.sh
+
+download_and_verify \
+    kreuger \
+    trimgalore \
+    0.6.6 \
+    b8db8ffd131d9d9e7c8532a5a1f1caee656c0c58d3eafd460fee3c39b9fcab5e \
+    https://github.com/FelixKrueger/TrimGalore/archive/\${version}.tar.gz \
+    TrimGalore-\${version}
+
+add_binary_path \
+    kreuger \
+    trimgalore


### PR DESCRIPTION
Trim galore will be used in cut&run pipeline. It is added to rnaseq docker as it requires Cutadapt and Fastqc.

## Checklist
<!--
Mark an `[x]` for completed items.
-->

* [x] Update CHANGELOG.rst for each commit separately:
  * Pay attention to write entries under the "Unreleased" section.
  * Mark all breaking changes as "**BACKWARD INCOMPATIBLE:**" and put them
    before non-breaking changes.
  * If a commit modifies a feature listed under "Unreleased" section,
    it might be sufficient to modify the existing CHANGELOG entry from previous
    commit(s).
* [ ] Bump the process version:
  * **MAJOR version (first number)**: Backward incompatible changes (changes
    that break the api/interface). Examples: renaming the input/output, adding
    mandatory input, removing input/output...
  * **MINOR version (middle number)**: add functionality or changes in a
    backwards-compatible manner. Examples: add output field, add non-mandatory
    input parameter, use a different tool that produces same results...
  * **PATCH version (last number)**: changes/bug fixes that do not affect
    the api/interface. Examples: typo fix, change/add warning messages...
* [ ] All inputs are used in process.
* [ ] All output fields have their ``re-save`` calls.