### PR TITLE
Alignment processes issue a warning on genome-read species mismatch

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -28,6 +28,10 @@ Changed
 - Add format parameter to ``macs2-callpeak``
 - Rewrite ``differentialexpression-edger`` to Python
 - Rewrite ``cuffdiff`` to Python
+- Alignment processes ``alignment-bowtie``, ``alignment-bowtie2``,
+  ``alignment-star``, ``alignment-bwa-mem``, ``alignment-bwa-sw``,
+  ``alignment-bwa-aln``, ``alignment-hisat2`` and ``walt`` now issue a
+  warning instead of an error when sample and genome species mismatch
 
 
 ===================

--- a/resolwe_bio/processes/WGBS/walt.yml
+++ b/resolwe_bio/processes/WGBS/walt.yml
@@ -14,7 +14,7 @@
       docker:
         image: resolwebio/wgbs:1.3.0
   data_name: "{{ reads|sample_name|default('?') }}"
-  version: 3.2.0
+  version: 3.3.0
   type: data:alignment:bam:walt
   category: Align
   flow_collection: sample
@@ -128,7 +128,7 @@
 
       {% if reads|sample|descriptor("general.species") %}
         {% if reads|sample|descriptor("general.species") != genome.species %}
-          re-error \
+          re-warning \
             {{ ('Species of reads (%s) and genome (%s) do not match.')
             | format(reads|sample|descriptor("general.species"), genome.species) }}
         {% endif %}

--- a/resolwe_bio/processes/alignment/bowtie.yml
+++ b/resolwe_bio/processes/alignment/bowtie.yml
@@ -13,7 +13,7 @@
     resources:
       cores: 10
   data_name: "{{ reads.fastq.0.file|basename|default('?') }}"
-  version: 2.1.0
+  version: 2.2.0
   type: data:alignment:bam:bowtie1
   category: Align
   flow_collection: sample
@@ -144,7 +144,7 @@
 
       {% if reads|sample|descriptor("general.species") %}
         {% if reads|sample|descriptor("general.species") != genome.species %}
-          re-error \
+          re-warning \
             {{ ('Species of reads (%s) and genome (%s) do not match.')
             | format(reads|sample|descriptor("general.species"), genome.species) }}
         {% endif %}
@@ -313,7 +313,7 @@
       memory: 16384
       cores: 20
   data_name: "{{ reads|sample_name|default('?') }}"
-  version: 2.2.0
+  version: 2.3.0
   type: data:alignment:bam:bowtie2
   category: Align
   flow_collection: sample
@@ -581,7 +581,7 @@
 
       {% if reads|sample|descriptor("general.species") %}
         {% if reads|sample|descriptor("general.species") != genome.species %}
-          re-error \
+          re-warning \
             {{ ('Species of reads (%s) and genome (%s) do not match.')
             | format(reads|sample|descriptor("general.species"), genome.species) }}
         {% endif %}

--- a/resolwe_bio/processes/alignment/bwa.yml
+++ b/resolwe_bio/processes/alignment/bwa.yml
@@ -14,7 +14,7 @@
       cores: 20
       memory: 16384
   data_name: "{{ reads|sample_name|default('?') }}"
-  version: 3.1.0
+  version: 3.2.0
   type: data:alignment:bam:bwamem
   category: Align
   flow_collection: sample
@@ -150,7 +150,7 @@
 
       {% if reads|sample|descriptor("general.species") %}
         {% if reads|sample|descriptor("general.species") != genome.species %}
-          re-error \
+          re-warning \
             {{ ('Species of reads (%s) and genome (%s) do not match.')
             | format(reads|sample|descriptor("general.species"), genome.species) }}
         {% endif %}
@@ -274,7 +274,7 @@
       cores: 20
       memory: 16384
   data_name: "{{ reads.fastq.0.file|basename|default('?') }}"
-  version: 2.1.0
+  version: 2.2.0
   type: data:alignment:bam:bwasw
   category: Align
   flow_collection: sample
@@ -345,7 +345,7 @@
 
       {% if reads|sample|descriptor("general.species") %}
         {% if reads|sample|descriptor("general.species") != genome.species %}
-          re-error \
+          re-warning \
             {{ ('Species of reads (%s) and genome (%s) do not match.')
             | format(reads|sample|descriptor("general.species"), genome.species) }}
         {% endif %}
@@ -452,7 +452,7 @@
       cores: 20
       memory: 16384
   data_name: "{{ reads|sample_name|default('?') }}"
-  version: 2.1.0
+  version: 2.2.0
   type: data:alignment:bam:bwaaln
   category: Align
   flow_collection: sample
@@ -549,7 +549,7 @@
 
       {% if reads|sample|descriptor("general.species") %}
         {% if reads|sample|descriptor("general.species") != genome.species %}
-          re-error \
+          re-warning \
             {{ ('Species of reads (%s) and genome (%s) do not match.')
             | format(reads|sample|descriptor("general.species"), genome.species) }}
         {% endif %}

--- a/resolwe_bio/processes/alignment/hisat2.yml
+++ b/resolwe_bio/processes/alignment/hisat2.yml
@@ -14,7 +14,7 @@
       docker:
         image: resolwebio/rnaseq:4.11.0
   data_name: "{{ reads|sample_name|default('?') }}"
-  version: 2.1.0
+  version: 2.2.0
   type: data:alignment:bam:hisat2
   category: Align
   flow_collection: sample
@@ -101,7 +101,7 @@
 
       {% if reads|sample|descriptor("general.species") %}
         {% if reads|sample|descriptor("general.species") != genome.species %}
-          re-error \
+          re-warning \
             {{ ('Species of reads (%s) and genome (%s) do not match.')
             | format(reads|sample|descriptor("general.species"), genome.species) }}
         {% endif %}

--- a/resolwe_bio/processes/alignment/star.yml
+++ b/resolwe_bio/processes/alignment/star.yml
@@ -14,7 +14,7 @@
       memory: 36864
       cores: 10
   data_name: "{{ reads|sample_name|default('?') }}"
-  version: 2.2.0
+  version: 2.3.0
   type: data:alignment:bam:star
   category: Align
   flow_collection: sample
@@ -404,7 +404,7 @@
 
       {% if reads|sample|descriptor("general.species") %}
         {% if reads|sample|descriptor("general.species") != genome.species %}
-          re-error \
+          re-warning \
             {{ ('Species of reads (%s) and genome (%s) do not match.')
             | format(reads|sample|descriptor("general.species"), genome.species) }}
         {% endif %}


### PR DESCRIPTION
Previously, when one wanted to align the same reads to two or more different species, an error was issued and process stopped. Here we relax this and make it a warning.


## Checklist
* [x] Update CHANGELOG.rst for each commit separately:
  * Pay attention to write entries under the "Unreleased" section.
  * Mark all breaking changes as "**BACKWARD INCOMPATIBLE:**" and put them
    before non-breaking changes.
  * If a commit modifies a feature listed under "Unreleased" section,
    it might be sufficient to modify the existing CHANGELOG entry from previous
    commit(s).
* [x] Bump the process version:
  * **MAJOR version (first number)**: Backward incompatible changes (changes
    that break the api/interface). Examples: renaming the input/output, adding
    mandatory input, removing input/output...
  * **MINOR version (middle number)**: add functionality or changes in a
    backwards-compatible manner. Examples: add output field, add non-mandatory
    input parameter, use a different tool that produces same results...
  * **PATCH version (last number)**: changes/bug fixes that do not affect
    the api/interface. Examples: typo fix, change/add warning messages...
* [x] All inputs are used in process.
* [x] All output fields have their ``re-save`` calls.
