### PR TITLE
Add BigWig timeout and bin size parameters

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -7,6 +7,17 @@ This project adheres to `Semantic Versioning <http://semver.org/>`_.
 
 
 ===================
+34.0.1 - 2020-10-20
+===================
+
+Fixed
+-------
+- Add BigWig timeout and bin size parameters to ``markduplicates``,
+  ``alignmentsieve`` and ``workflow-cutnrun``. Add bin size parameter
+  to ``alignment-bowtie2``.
+
+
+===================
 34.0.0 - 2020-10-19
 ===================
 

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -7,8 +7,13 @@ This project adheres to `Semantic Versioning <http://semver.org/>`_.
 
 
 ===================
-34.0.1 - 2020-10-20
+34.1.0 - 2020-10-20
 ===================
+
+Added
+-------
+- Add peakcalling to removed duplicates step in species' line of the
+  ``workflow-cutnrun`` workflow
 
 Fixed
 -------

--- a/resolwe_bio/processes/alignment/bowtie.yml
+++ b/resolwe_bio/processes/alignment/bowtie.yml
@@ -313,7 +313,7 @@
       memory: 16384
       cores: 20
   data_name: "{{ reads|sample_name|default('?') }}"
-  version: 2.3.0
+  version: 2.4.0
   type: data:alignment:bam:bowtie2
   category: Align
   flow_collection: sample
@@ -547,6 +547,13 @@
     - name: misc_opts
       label: Miscellaneous options
       group:
+        - name: bw_binsize
+          label: BigWig bin size
+          type: basic:integer
+          default: 50
+          description: |
+            Size of the bins, in bases, for the output of the bigwig/bedgraph file.
+            Default is 50.
         - name: bw_timeout
           label: BigWig timeout (s)
           type: basic:integer
@@ -821,5 +828,5 @@
       re-save species {{genome.species}}
       re-save build {{genome.build}}
 
-      #computation time limit for bamCoverage is 480s per GB
-      bamtobigwig.sh "${FW_NAME}.bam" {{ requirements.resources.cores }} 50 {{ misc_opts.bw_timeout }} {{ genome.species }}
+      #computation time limit for bamCoverage is by default 480s per GB
+      bamtobigwig.sh "${FW_NAME}.bam" {{ requirements.resources.cores }} {{ misc_opts.bw_binsize }} {{ misc_opts.bw_timeout }} {{ genome.species }}

--- a/resolwe_bio/processes/workflows/cut_and_run.yml
+++ b/resolwe_bio/processes/workflows/cut_and_run.yml
@@ -3,7 +3,7 @@
   data_name: "{{reads|sample_name|default('?')}}"
   requirements:
     expression-engine: jinja
-  version: 1.1.0
+  version: 1.2.0
   type: data:workflow:cutnrun
   category: Pipeline
   description: |
@@ -605,6 +605,15 @@
           bigwig_opts:
             bigwig_binsize: "{{input.options_misc.bw_binsize}}"
             bigwig_timeout: "{{input.options_misc.bigwig_timeout}}"
+      - id: species_rmdup_pc
+        run: macs2-callpeak
+        input:
+          case: "{{steps.species_rmdup}}"
+          settings:
+            format: "{{input.options_pc.format}}"
+            pvalue: "{{input.options_pc.pvalue}}"
+            duplicates: "{{input.options_pc.duplicates}}"
+            bedgraph: "{{input.options_pc.bedgraph}}"
       - id: species_rmdup_frag
         run: alignmentsieve
         input:

--- a/resolwe_bio/processes/workflows/cut_and_run.yml
+++ b/resolwe_bio/processes/workflows/cut_and_run.yml
@@ -3,7 +3,7 @@
   data_name: "{{reads|sample_name|default('?')}}"
   requirements:
     expression-engine: jinja
-  version: 1.0.0
+  version: 1.1.0
   type: data:workflow:cutnrun
   category: Pipeline
   description: |
@@ -502,6 +502,24 @@
             Magnitude of the scale factor. The scaling factor is calculated by
             dividing the scale with the number of features in BEDPE (scale/(number of
             features)).
+    - name: options_misc
+      label: Miscellaneous options
+      group:
+        - name: bw_binsize
+          label: BigWig bin size
+          type: basic:integer
+          default: 50
+          description: |
+            Size of the bins, in bases, for the output of the bigwig/bedgraph file.
+            Default is 50.
+        - name: bw_timeout
+          label: BigWig timeout
+          type: basic:integer
+          default: 3600
+          description: |
+            Number of seconds before calculation of BigWig file is aborted. Default
+            is 3600 seconds (1 hour).
+
   run:
     language: workflow
     program:
@@ -549,6 +567,9 @@
             dovetail: "{{input.options_aln_species.dovetail}}"
           output_opts:
             no_unal: "{{input.options_aln_species.no_unal}}"
+          misc_opts:
+            bw_binsize: "{{input.options_misc.bw_binsize}}"
+            bw_timeout: "{{input.options_misc.bw_timeout}}"
       - id: species_pc
         run: macs2-callpeak
         input:
@@ -564,6 +585,9 @@
           alignment: "{{steps.species_align}}"
           min_fragment_length: "{{input.options_sieve.min_frag_length}}"
           max_fragment_length: "{{input.options_sieve.max_frag_length}}"
+          bigwig_opts:
+            bigwig_binsize: "{{input.options_misc.bw_binsize}}"
+            bigwig_timeout: "{{input.options_misc.bw_timeout}}"
       - id: species_align_frag_pc
         run: macs2-callpeak
         input:
@@ -578,12 +602,18 @@
         input:
           bam: "{{steps.species_align}}"
           remove_duplicates: true
+          bigwig_opts:
+            bigwig_binsize: "{{input.options_misc.bw_binsize}}"
+            bigwig_timeout: "{{input.options_misc.bigwig_timeout}}"
       - id: species_rmdup_frag
         run: alignmentsieve
         input:
           alignment: "{{steps.species_rmdup}}"
           min_fragment_length: "{{input.options_sieve.min_frag_length}}"
           max_fragment_length: "{{input.options_sieve.max_frag_length}}"
+          bigwig_opts:
+            bigwig_binsize: "{{input.options_misc.bw_binsize}}"
+            bigwig_timeout: "{{input.options_misc.bw_timeout}}"
       - id: species_rmdup_frag_pc
         run: macs2-callpeak
         input:
@@ -609,11 +639,17 @@
             dovetail: "{{input.options_aln_spikein.dovetail}}"
           output_opts:
             no_unal: "{{input.options_aln_spikein.no_unal}}"
+          misc_opts:
+            bw_binsize: "{{input.options_misc.bw_binsize}}"
+            bw_timeout: "{{input.options_misc.bw_timeout}}"
       - id: spikein_rmdup
         run: markduplicates
         input:
           bam: '{{steps.spikein_align}}'
           remove_duplicates: true
+          bigwig_opts:
+            bigwig_binsize: "{{input.options_misc.bw_binsize}}"
+            bigwig_timeout: "{{input.options_misc.bw_timeout}}"
       - id: spikein_normfactor
         run: bedtools-bamtobed
         input:

--- a/resolwe_bio/tests/processes/test_alignment.py
+++ b/resolwe_bio/tests/processes/test_alignment.py
@@ -143,6 +143,10 @@ class AlignmentProcessorTestCase(KBBioProcessTestCase):
                 "rfg": "5,3",
                 "score_min": "L,-0.6,-0.6",
             },
+            "misc_opts": {
+                "bw_binsize": 50,
+                "bw_timeout": 30,
+            },
         }
         single_end = self.run_process("alignment-bowtie2", inputs)
         self.assertFile(single_end, "stats", output_folder / "bowtie2_reads_report.txt")

--- a/resolwe_bio/tests/processes/test_reads_filtering.py
+++ b/resolwe_bio/tests/processes/test_reads_filtering.py
@@ -454,7 +454,14 @@ class ReadsFilteringProcessorTestCase(BioProcessTestCase):
         self.assertFile(skipped_md, "bam", primerclipped)
 
         # Test that removal of duplicates works.
-        md_inputs = {"bam": bam.id, "remove_duplicates": True}
+        md_inputs = {
+            "bam": bam.id,
+            "remove_duplicates": True,
+            "bigwig_opts": {
+                "bigwig_binsize": 50,
+                "bigwig_timeout": 30,
+            },
+        }
         removed_md = self.run_process("markduplicates", md_inputs)
 
         def filter_startedon(line):
@@ -586,6 +593,10 @@ class ReadsFilteringProcessorTestCase(BioProcessTestCase):
         params = {
             "alignment": bam.id,
             "max_fragment_length": 149,
+            "bigwig_opts": {
+                "bigwig_binsize": 50,
+                "bigwig_timeout": 30,
+            },
         }
 
         max_filteredbam = self.run_process("alignmentsieve", params)

--- a/resolwe_bio/tests/workflows/test_cut_and_run.py
+++ b/resolwe_bio/tests/workflows/test_cut_and_run.py
@@ -40,6 +40,10 @@ class CutAndRunTestCase(BioProcessTestCase):
             "options_sieve": {
                 "max_frag_length": 120,
             },
+            "options_misc": {
+                "bw_binsize": 50,
+                "bw_timeout": 30,
+            },
         }
 
         self.run_process("workflow-cutnrun", input_workflow)


### PR DESCRIPTION
Primary reason for this PR is the addition of timeout parameter to `workflow-cutnrun` and corresponding processes. Due to the way the `bamtobigwig.sh` script is written, it makes sense to also add bin size.

* [x] Update CHANGELOG.rst for each commit separately:
  * Pay attention to write entries under the "Unreleased" section.
  * Mark all breaking changes as "**BACKWARD INCOMPATIBLE:**" and put them
    before non-breaking changes.
  * If a commit modifies a feature listed under "Unreleased" section,
    it might be sufficient to modify the existing CHANGELOG entry from previous
    commit(s).
* [x] Bump the process version:
  * **MAJOR version (first number)**: Backward incompatible changes (changes
    that break the api/interface). Examples: renaming the input/output, adding
    mandatory input, removing input/output...
  * **MINOR version (middle number)**: add functionality or changes in a
    backwards-compatible manner. Examples: add output field, add non-mandatory
    input parameter, use a different tool that produces same results...
  * **PATCH version (last number)**: changes/bug fixes that do not affect
    the api/interface. Examples: typo fix, change/add warning messages...
* [x] All inputs are used in process.
* [x] All output fields have their ``re-save`` calls.