### PR TITLE
Add id field to Feature and Mapping serializers

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -12,6 +12,7 @@ Unreleased
 Added
 -------
 - Add initial general clinical descriptor schema ``general_clinical``
+- Add ``id`` field to ``Feature`` and ``Mapping`` serializers
 
 
 ===================

--- a/resolwe_bio/kb/serializers.py
+++ b/resolwe_bio/kb/serializers.py
@@ -24,6 +24,7 @@ class FeatureSerializer(SelectiveFieldMixin, serializers.ModelSerializer):
             "description",
             "feature_id",
             "full_name",
+            "id",
             "name",
             "source",
             "species",
@@ -40,6 +41,7 @@ class MappingSerializer(SelectiveFieldMixin, serializers.ModelSerializer):
 
         model = Mapping
         fields = [
+            "id",
             "relation_type",
             "source_db",
             "source_id",

--- a/resolwe_bio/kb/tests/test_feature.py
+++ b/resolwe_bio/kb/tests/test_feature.py
@@ -192,6 +192,26 @@ class FeatureTestCase(TestCase, APITestCase):
         )
         self.assertEqual(len(response.data), 1)
 
+    def test_serialization(self):
+        FEATURE_SEARCH_URL = reverse("resolwebio-api:kb_feature_search")
+        kwargs = {"feature_id": "FT-0"}
+
+        feature = Feature.objects.get(**kwargs)
+        response = self.client.get(FEATURE_SEARCH_URL, kwargs, format="json")
+        self.assertEqual(len(response.data), 1)
+
+        serialized_feature = response.data[0]
+        self.assertEqual(serialized_feature["aliases"], feature.aliases)
+        self.assertEqual(serialized_feature["description"], feature.description)
+        self.assertEqual(serialized_feature["feature_id"], feature.feature_id)
+        self.assertEqual(serialized_feature["full_name"], feature.full_name)
+        self.assertEqual(serialized_feature["id"], feature.id)
+        self.assertEqual(serialized_feature["name"], feature.name)
+        self.assertEqual(serialized_feature["source"], feature.source)
+        self.assertEqual(serialized_feature["species"], feature.species)
+        self.assertEqual(serialized_feature["sub_type"], feature.sub_type)
+        self.assertEqual(serialized_feature["type"], feature.type)
+
     def test_feature_autocomplete(self):
         FEATURE_AUTOCOMPLETE_URL = reverse("resolwebio-api:kb_feature_autocomplete")
 

--- a/resolwe_bio/kb/tests/test_mapping.py
+++ b/resolwe_bio/kb/tests/test_mapping.py
@@ -79,3 +79,21 @@ class MappingTestCase(APITestCase, TestCase):
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_serialization(self):
+        MAPPING_URL = reverse("resolwebio-api:kb_mapping_search")
+        kwargs = {"source_id": "FT1"}
+
+        mapping = Mapping.objects.get(**kwargs)
+        response = self.client.get(MAPPING_URL, kwargs, format="json")
+        self.assertEqual(len(response.data), 1)
+
+        serialized_mapping = response.data[0]
+        self.assertEqual(serialized_mapping["id"], mapping.id)
+        self.assertEqual(serialized_mapping["relation_type"], mapping.relation_type)
+        self.assertEqual(serialized_mapping["source_db"], mapping.source_db)
+        self.assertEqual(serialized_mapping["source_id"], mapping.source_id)
+        self.assertEqual(serialized_mapping["source_species"], mapping.source_species)
+        self.assertEqual(serialized_mapping["target_db"], mapping.target_db)
+        self.assertEqual(serialized_mapping["target_id"], mapping.target_id)
+        self.assertEqual(serialized_mapping["target_species"], mapping.target_species)


### PR DESCRIPTION
Motivation for this PR: fix the issue with iterate() in ReSDK, that relies on object's id. But until now, filtering by id was not possible for features / mappings. 