### PR TITLE
Update template table in upload-orange-metadata

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -14,6 +14,11 @@ Added
 - Add initial general clinical descriptor schema ``general_clinical``
 - Add ``id`` field to ``Feature`` and ``Mapping`` serializers
 
+Changed
+-------
+- Update the url for the Orange table example template in
+  ``upload-orange-metadata``
+
 
 ===================
 34.2.1 - 2020-11-17

--- a/resolwe_bio/processes/import_data/metadata.py
+++ b/resolwe_bio/processes/import_data/metadata.py
@@ -80,14 +80,14 @@ class UploadOrangeMetadata(Process):
     [documentation](https://orange-visual-programming.readthedocs.io/loading-your-data/index.html#header-with-attribute-type-information).
 
     An example of native tab-delimited format can be downloaded
-    [here](http://file.biolab.si/datasets/sample-head.xlsx).
+    [here](https://drive.google.com/file/d/1FR9LNraQ88lDYrSqfS8NnwxRsC6IP8ix/view?usp=sharing).
 
     """
 
     slug = "upload-orange-metadata"
     name = "Metadata table for Orange"
     process_type = "data:metadata:orange"
-    version = "1.0.0"
+    version = "1.0.1"
     category = "Import"
     scheduling_class = SchedulingClass.BATCH
     requirements = {


### PR DESCRIPTION
Template in update-orange-template needs to be updated to include mS#Sample, ms#Sample name, mS#Sample ID and mS#Sample slug. The template is now located on our google drive and can be changed if needed.

## Checklist
<!--
Mark an `[x]` for completed items.
-->

* [x] Update CHANGELOG.rst for each commit separately:
  * Pay attention to write entries under the "Unreleased" section.
  * Mark all breaking changes as "**BACKWARD INCOMPATIBLE:**" and put them
    before non-breaking changes.
  * If a commit modifies a feature listed under "Unreleased" section,
    it might be sufficient to modify the existing CHANGELOG entry from previous
    commit(s).
* [x] Bump the process version:
  * **MAJOR version (first number)**: Backward incompatible changes (changes
    that break the api/interface). Examples: renaming the input/output, adding
    mandatory input, removing input/output...
  * **MINOR version (middle number)**: add functionality or changes in a
    backwards-compatible manner. Examples: add output field, add non-mandatory
    input parameter, use a different tool that produces same results...
  * **PATCH version (last number)**: changes/bug fixes that do not affect
    the api/interface. Examples: typo fix, change/add warning messages...
* [x] All inputs are used in process.
* [x] All output fields have their ``re-save`` calls.

