### PR TITLE
Fix quality recoding in SRA import processes

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -28,6 +28,8 @@ Fixed
 -----
 - Fix file import in processes ``upload-multiplexed-single`` and
   ``upload-multiplexed-paired``
+- Fix ``import-sra-paired`` and ``import-sra-paired`` to correctly
+  determine Illumina 1.5 and 1.3 encoding and run recoding.
 
 
 ===================

--- a/resolwe_bio/processes/import_data/sra_file.py
+++ b/resolwe_bio/processes/import_data/sra_file.py
@@ -149,7 +149,7 @@ class ImportSraSingle(Process):
     slug = "import-sra-single"
     name = "SRA data (single-end)"
     process_type = "data:reads:fastq:single"
-    version = "1.4.2"
+    version = "1.4.3"
     category = "Import"
     scheduling_class = SchedulingClass.BATCH
     persistence = Persistence.RAW
@@ -283,16 +283,20 @@ class ImportSraSingle(Process):
             encoding_file = report_dir / "fastqc_data.txt"
             encoding = Cmd["parse_encoding_type.py"](str(encoding_file))
 
-            if encoding == "Illumina 1.5" or encoding == "Illumina 1.3":
+            if encoding == "Illumina 1.5\n" or encoding == "Illumina 1.3\n":
                 print("Recoding input reads from Phred64 encoding to Phred33 encoding.")
                 Path(f"{reads_name}.fastq.gz").rename("input_reads.fastq.gz")
-                Cmd[
-                    "TrimmomaticSE",
-                    "-phred64",
-                    "input_reads.fastq.gz",
-                    "reformated.fastq.gz",
-                    "TOPHRED33",
-                ]()
+                return_code, _, _ = (
+                    Cmd["TrimmomaticSE"][
+                        "-phred64",
+                        "input_reads.fastq.gz",
+                        "reformated.fastq.gz",
+                        "TOPHRED33",
+                    ]
+                    & TEE(retcode=None)
+                )
+                if return_code:
+                    self.error(f"Recoding of input reads failed.")
                 Path("reformated.fastq.gz").rename(f"{reads_name}.fastq.gz")
 
             elif encoding != "Sanger / Illumina 1.9\n":
@@ -317,7 +321,7 @@ class ImportSraPaired(Process):
     slug = "import-sra-paired"
     name = "SRA data (paired-end)"
     process_type = "data:reads:fastq:paired"
-    version = "1.4.2"
+    version = "1.4.3"
     category = "Import"
     scheduling_class = SchedulingClass.BATCH
     persistence = Persistence.RAW
@@ -467,16 +471,20 @@ class ImportSraPaired(Process):
             encoding_file = report_dir / "fastqc_data.txt"
             encoding = Cmd["parse_encoding_type.py"](str(encoding_file))
 
-            if encoding == "Illumina 1.5" or encoding == "Illumina 1.3":
+            if encoding == "Illumina 1.5\n" or encoding == "Illumina 1.3\n":
                 print("Recoding input reads from Phred64 encoding to Phred33 encoding.")
                 Path(f"{reads_name}.fastq.gz").rename("input_reads.fastq.gz")
-                Cmd[
-                    "TrimmomaticSE",
-                    "-phred64",
-                    "input_reads.fastq.gz",
-                    "reformated.fastq.gz",
-                    "TOPHRED33",
-                ]()
+                return_code, _, _ = (
+                    Cmd["TrimmomaticSE"][
+                        "-phred64",
+                        "input_reads.fastq.gz",
+                        "reformated.fastq.gz",
+                        "TOPHRED33",
+                    ]
+                    & TEE(retcode=None)
+                )
+                if return_code:
+                    self.error(f"Recoding of input reads failed.")
                 Path("reformated.fastq.gz").rename(f"{reads_name}.fastq.gz")
 
             elif encoding != "Sanger / Illumina 1.9\n":

--- a/resolwe_bio/tests/processes/test_import.py
+++ b/resolwe_bio/tests/processes/test_import.py
@@ -108,6 +108,15 @@ class ImportProcessorTestCase(BioProcessTestCase):
             ],
         )
 
+        # Test the upload of reads where Illumina 1.5 encoding is detected.
+        inputs = {
+            "sra_accession": ["SRR13627909"],
+            "advanced": {"max_spot_id": 1, "prefetch": False},
+        }
+        self.run_process("import-sra", inputs)
+        for data in Data.objects.all():
+            self.assertStatus(data, Data.STATUS_DONE)
+
         # test error messages
         sra = self.run_process(
             "import-sra-single",


### PR DESCRIPTION
This fixes recoding of Illumina 1.5 and 1.3 encoding. Encoding is determined by parsing FASTQC output file using `parse_encoding_type.py` tool which prints the encoding to stdout. By default newline is added at the end of the print statement. 

## Checklist
<!--
Mark an `[x]` for completed items.
-->

* [x] Update CHANGELOG.rst for each commit separately:
  * Pay attention to write entries under the "Unreleased" section.
  * Mark all breaking changes as "**BACKWARD INCOMPATIBLE:**" and put them
    before non-breaking changes.
  * If a commit modifies a feature listed under "Unreleased" section,
    it might be sufficient to modify the existing CHANGELOG entry from previous
    commit(s).
* [x] Bump the process version:
  * **MAJOR version (first number)**: Backward incompatible changes (changes
    that break the api/interface). Examples: renaming the input/output, adding
    mandatory input, removing input/output...
  * **MINOR version (middle number)**: add functionality or changes in a
    backwards-compatible manner. Examples: add output field, add non-mandatory
    input parameter, use a different tool that produces same results...
  * **PATCH version (last number)**: changes/bug fixes that do not affect
    the api/interface. Examples: typo fix, change/add warning messages...
* [x] All inputs are used in process.
* [x] All output fields have their ``re-save`` calls.