### PR TITLE
Remove Ensembl IDs and add extra variables to SeSAMe output

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -6,6 +6,16 @@ All notable changes to this project are documented in this file.
 This project adheres to `Semantic Versioning <http://semver.org/>`_.
 
 
+==========
+Unreleased
+==========
+
+Changed
+-------
+
+- Remove mapping of probe_ids to ENSEMBL ids and add extra variables in
+  ``methylation-array-sesame`` process
+
 ===================
 38.1.0 - 2021-06-14
 ===================

--- a/resolwe_bio/tests/files/large/methylation_beta_values_annotated.txt.gz
+++ b/resolwe_bio/tests/files/large/methylation_beta_values_annotated.txt.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3b89217ec7437043036815edbb9979da8706c643f0d525f39833114da2d04dc6
-size 14632600
+oid sha256:a495986190d7ee7abd2cf623a6e2f7a78f4ef8a34e0bace5ef85ee9c1a9f4f2a
+size 15637798


### PR DESCRIPTION
Ensembl ID mapping of probes has been removed for now.

In addition, probe chromosome position, stand/end of CpG and
strand have been added to the output of the SeSAMe pipeline.

## Checklist
<!--
Mark an `[x]` for completed items.
-->

* [x] Update CHANGELOG.rst for each commit separately:
  * Pay attention to write entries under the "Unreleased" section.
  * Mark all breaking changes as "**BACKWARD INCOMPATIBLE:**" and put them
    before non-breaking changes.
  * If a commit modifies a feature listed under "Unreleased" section,
    it might be sufficient to modify the existing CHANGELOG entry from previous
    commit(s).
* [x] Bump the process version:
  * **MAJOR version (first number)**: Backward incompatible changes (changes
    that break the api/interface). Examples: renaming the input/output, adding
    mandatory input, removing input/output...
  * **MINOR version (middle number)**: add functionality or changes in a
    backwards-compatible manner. Examples: add output field, add non-mandatory
    input parameter, use a different tool that produces same results...
  * **PATCH version (last number)**: changes/bug fixes that do not affect
    the api/interface. Examples: typo fix, change/add warning messages...
* [x] All inputs are used in process.
* [x] All output fields have their ``re-save`` calls.
