### PR TITLE
Return betas and improve docstrings for methylation-array-sesame pipeline

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -12,6 +12,8 @@ Unreleased
 
 Added
 -----
+- Add more information about output to the ``methylation-array-sesame``
+  pipeline documentation
 
 Changed
 -------

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -19,6 +19,7 @@ Changed
 Fixed
 -----
 - Fix stalled sam-to-bam conversion in ``wgs-preprocess`` process
+- Return column betas to ``methylation-array-sesame`` pipeline output
 
 
 ===================

--- a/resolwe_bio/processes/microarray/methylation_arrays.py
+++ b/resolwe_bio/processes/microarray/methylation_arrays.py
@@ -34,7 +34,7 @@ class MethylationArraySesame(ProcessBio):
     slug = "methylation-array-sesame"
     name = "Methylation analysis (SeSAMe)"
     process_type = "data:methylation:sesame"
-    version = "1.2.0"
+    version = "1.2.1"
     category = "Methylation arrays"
     data_name = 'SeSAMe array ({{ idat_file.red_channel.file|default("?") }})'
     scheduling_class = SchedulingClass.BATCH

--- a/resolwe_bio/processes/microarray/methylation_arrays.py
+++ b/resolwe_bio/processes/microarray/methylation_arrays.py
@@ -28,13 +28,15 @@ class MethylationArraySesame(ProcessBio):
     some basic statistics, such as mean beta, fraction of
     (un)methylated, GCT, predicted ethnicity, gender and age.
     Methylation data file holds betas, mvals and pvals for probe ids.
-    In addition, Ensembl IDs and HGNC gene symbol names are provided.
+    In addition, Ensembl IDs and HGNC gene symbol names are provided,
+    along with chromosome and start/end positions of CpG sites
+    (1-based).
     """
 
     slug = "methylation-array-sesame"
     name = "Methylation analysis (SeSAMe)"
     process_type = "data:methylation:sesame"
-    version = "1.2.1"
+    version = "1.2.2"
     category = "Methylation arrays"
     data_name = 'SeSAMe array ({{ idat_file.red_channel.file|default("?") }})'
     scheduling_class = SchedulingClass.BATCH

--- a/resolwe_bio/tests/files/large/methylation_beta_values_annotated.txt.gz
+++ b/resolwe_bio/tests/files/large/methylation_beta_values_annotated.txt.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a495986190d7ee7abd2cf623a6e2f7a78f4ef8a34e0bace5ef85ee9c1a9f4f2a
-size 15637798
+oid sha256:e46fc334fe22df26611023316529610d415540189a6b372306cf30ed0b1b8a53
+size 19556270

--- a/resolwe_bio/tools/sesame.R
+++ b/resolwe_bio/tools/sesame.R
@@ -122,7 +122,7 @@ rownames(pvals) <- NULL
 message("Performing left join on betas and p-values.")
 ann <- merge(x = ann.betas, y = mvals, all.x = TRUE)
 ann <- merge(x = ann, y = pvals, all.x = TRUE)
-colsel <- c("probe_ids", "gene_HGNC", "chr", "start", "end", "strand", "mvals", "pvals")
+colsel <- c("probe_ids", "gene_HGNC", "chr", "start", "end", "strand", "betas", "mvals", "pvals")
 ann <- ann[, colsel]
 
 message("Writing results to a gz file.")


### PR DESCRIPTION
Two things are changed in this ~bugfix:

* docstring now documents that start and end position are 1- based
* betas column was removed from output by accident on the last refactoring and is now returned


## Checklist
* [x] Update CHANGELOG.rst for each commit separately:
  * Pay attention to write entries under the "Unreleased" section.
  * Mark all breaking changes as "**BACKWARD INCOMPATIBLE:**" and put them
    before non-breaking changes.
  * If a commit modifies a feature listed under "Unreleased" section,
    it might be sufficient to modify the existing CHANGELOG entry from previous
    commit(s).
* [x] Bump the process version:
  * **MAJOR version (first number)**: Backward incompatible changes (changes
    that break the api/interface). Examples: renaming the input/output, adding
    mandatory input, removing input/output...
  * **MINOR version (middle number)**: add functionality or changes in a
    backwards-compatible manner. Examples: add output field, add non-mandatory
    input parameter, use a different tool that produces same results...
  * **PATCH version (last number)**: changes/bug fixes that do not affect
    the api/interface. Examples: typo fix, change/add warning messages...
* [x] All inputs are used in process.
* [x] All output fields have their ``re-save`` calls.
