### PR TITLE
Use clean file name for gene sets in create_gene_sets.py

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -6,6 +6,15 @@ All notable changes to this project are documented in this file.
 This project adheres to `Semantic Versioning <http://semver.org/>`_.
 
 
+==========
+Unreleased
+==========
+
+Fixed
+-----
+- Use clean file name for gene sets from differential expressions
+
+
 ===================
 38.2.0 - 2021-07-13
 ===================

--- a/resolwe_bio/tools/create_gene_sets.py
+++ b/resolwe_bio/tools/create_gene_sets.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Create gene set table."""
 import argparse
+import re
 from pathlib import Path
 
 import pandas as pd
@@ -39,10 +40,12 @@ def save_genes(data_frame, outfname):
 
 def generate_name(analysis_name, tool_name, logfc=1, fdr=0.05):
     """Generate name for gene sets."""
-    if " " in analysis_name:
-        analysis_name = analysis_name.replace(" ", "_")
-    if " " in tool_name:
-        tool_name = tool_name.replace(" ", "_")
+    analysis_name = analysis_name.strip().replace(" ", "_")
+    analysis_name = re.sub(r"[^-\w.]", "", analysis_name)
+
+    tool_name = tool_name.strip().replace(" ", "_")
+    tool_name = re.sub(r"[^-\w.]", "", tool_name)
+
     return f"{analysis_name}_{tool_name}_logFC{logfc}_FDR{fdr}"
 
 


### PR DESCRIPTION
Gene set upload could fail if unsafe characters were used. Here we implement the [approach](https://github.com/django/django/blob/795051b2b04020866fc14c858b77972ef8e5a3e2/django/utils/text.py#L225) used in Django to create clean file names.

## Checklist
<!--
Mark an `[x]` for completed items.
-->

* [x] Update CHANGELOG.rst for each commit separately:
  * Pay attention to write entries under the "Unreleased" section.
  * Mark all breaking changes as "**BACKWARD INCOMPATIBLE:**" and put them
    before non-breaking changes.
  * If a commit modifies a feature listed under "Unreleased" section,
    it might be sufficient to modify the existing CHANGELOG entry from previous
    commit(s).
* [x] Bump the process version:
  * **MAJOR version (first number)**: Backward incompatible changes (changes
    that break the api/interface). Examples: renaming the input/output, adding
    mandatory input, removing input/output...
  * **MINOR version (middle number)**: add functionality or changes in a
    backwards-compatible manner. Examples: add output field, add non-mandatory
    input parameter, use a different tool that produces same results...
  * **PATCH version (last number)**: changes/bug fixes that do not affect
    the api/interface. Examples: typo fix, change/add warning messages...
* [x] All inputs are used in process.
* [x] All output fields have their ``re-save`` calls.
