### PR TITLE
Fix data name and advanced options in GATK VariantsToTable process

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -41,6 +41,7 @@ Changed
 
 Fixed
 -----
+- Fix data name and advanced options in ``variants-to-table`` process
 
 
 ===================

--- a/resolwe_bio/processes/variant_calling/variants_to_table.py
+++ b/resolwe_bio/processes/variant_calling/variants_to_table.py
@@ -28,7 +28,7 @@ class GatkVariantsToTable(Process):
     name = "GATK VariantsToTable"
     category = "GATK"
     process_type = "data:variantstable"
-    version = "1.0.0"
+    version = "1.0.1"
     scheduling_class = SchedulingClass.BATCH
     requirements = {
         "expression-engine": "jinja",
@@ -41,7 +41,7 @@ class GatkVariantsToTable(Process):
             "storage": 200,
         },
     }
-    data_name = '{{vcf.file|default("?") }}'
+    data_name = "Variants in table"
 
     class Input:
         """Input fields for GATK VariantsToTable."""
@@ -110,8 +110,6 @@ class GatkVariantsToTable(Process):
         args = [
             "-V",
             inputs.vcf.output.vcf.path,
-            "--split-multi-allelic",
-            inputs.advanced_options.split_alleles,
             "-O",
             variants_table,
         ]
@@ -121,6 +119,9 @@ class GatkVariantsToTable(Process):
 
         for gf_field in inputs.advanced_options.gf_fields:
             args.extend(["-GF", gf_field])
+
+        if inputs.advanced_options.split_alleles:
+            args.append("--split-multi-allelic")
 
         return_code, _, _ = Cmd["gatk"]["VariantsToTable"][args] & TEE(retcode=None)
         if return_code:


### PR DESCRIPTION
## Checklist
<!--
Mark an `[x]` for completed items.
-->

* [ x] Update CHANGELOG.rst for each commit separately:
  * Pay attention to write entries under the "Unreleased" section.
  * Mark all breaking changes as "**BACKWARD INCOMPATIBLE:**" and put them
    before non-breaking changes.
  * If a commit modifies a feature listed under "Unreleased" section,
    it might be sufficient to modify the existing CHANGELOG entry from previous
    commit(s).
* [ x] Bump the process version:
  * **MAJOR version (first number)**: Backward incompatible changes (changes
    that break the api/interface). Examples: renaming the input/output, adding
    mandatory input, removing input/output...
  * **MINOR version (middle number)**: add functionality or changes in a
    backwards-compatible manner. Examples: add output field, add non-mandatory
    input parameter, use a different tool that produces same results...
  * **PATCH version (last number)**: changes/bug fixes that do not affect
    the api/interface. Examples: typo fix, change/add warning messages...
* [ x] All inputs are used in process.
* [ x] All output fields have a value assigned to them.
