### PR TITLE
Set independent field to True in DESeq2 process

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -27,6 +27,9 @@ Changed
   ``files-to-fastq-single`` and ``files-to-fastq-paired`` to Python
 - Add java memory setting and remove unused inputs in
   ``gatk-genotype-gvcfs``
+- Change the ``independent`` field to True by default in process
+  ``differentialexpression-deseq2`` to match the behaviour of the R
+  script
 
 Fixed
 -----

--- a/resolwe_bio/processes/differential_expression/deseq.py
+++ b/resolwe_bio/processes/differential_expression/deseq.py
@@ -35,7 +35,7 @@ class Deseq(Process):
     slug = "differentialexpression-deseq2"
     name = "DESeq2"
     process_type = "data:differentialexpression:deseq2"
-    version = "3.3.0"
+    version = "3.4.0"
     category = "Differential Expression"
     scheduling_class = SchedulingClass.BATCH
     persistence = Persistence.CACHED
@@ -125,7 +125,7 @@ class Deseq(Process):
             )
             independent = BooleanField(
                 label="Apply independent gene filtering",
-                default=False,
+                default=True,
             )
             alpha = FloatField(
                 label="Significance cut-off used for optimizing independent "
@@ -241,7 +241,7 @@ class Deseq(Process):
         if inputs.filter_options.cook:
             params.extend(["--cooks-cutoff", inputs.filter_options.cooks_cutoff])
         if inputs.filter_options.independent:
-            params.extend(["--alpha", inputs.filter_options.alpha])
+            params.extend(["--independent", "--alpha", inputs.filter_options.alpha])
 
         return_code, _, _ = Cmd["deseq.R"][params] & TEE(retcode=None)
         self.progress(0.95)

--- a/resolwe_bio/tests/processes/test_diff_expression.py
+++ b/resolwe_bio/tests/processes/test_diff_expression.py
@@ -105,6 +105,14 @@ class DiffExpProcessorTestCase(KBBioProcessTestCase):
         self.assertFields(gene_set, "species", "Dictyostelium discoideum")
         self.assertFields(gene_set, "source", "DICTYBASE")
 
+        inputs["filter_options"]["independent"] = False
+        diff_exp = self.run_process("differentialexpression-deseq2", inputs)
+        self.assertFileExists(diff_exp, "raw")
+        self.assertFields(diff_exp, "source", "DICTYBASE")
+        self.assertFields(diff_exp, "species", "Dictyostelium discoideum")
+        self.assertFields(diff_exp, "build", "dd-05-2009")
+        self.assertFields(diff_exp, "feature_type", "gene")
+
     @with_resolwe_host
     @tag_process("differentialexpression-deseq2")
     def test_deseq2_source(self):

--- a/resolwe_bio/tools/deseq.R
+++ b/resolwe_bio/tools/deseq.R
@@ -17,6 +17,7 @@ parser$add_argument('--controls', nargs='+', help='Controls', required=TRUE)
 parser$add_argument('--beta-prior', action='store_true')
 parser$add_argument('--min-count-sum', type='integer', help='Minimum count sum', default=0)
 parser$add_argument('--cooks-cutoff', type='double', help="Cook's cut-off", default=FALSE)
+parser$add_argument('--independent', help="Independent filtering", action="store_true")
 parser$add_argument('--alpha', type='double', help="Alpha", default=0.1)
 parser$add_argument('--format', choices=c('rc', 'rsem', 'salmon', 'nanostring'), default='rc')
 parser$add_argument('--tx2gene', help='Transcript to gene mapping')
@@ -63,7 +64,9 @@ if (args$format == 'rsem') {
 dds <- dds[rowSums(counts(dds)) >= args$min_count_sum, ]
 dds <- tryCatch(DESeq(dds, betaPrior=args$beta_prior), error=error)
 
-result <- results(dds, cooksCutoff=args$cooks_cutoff, alpha=args$alpha)
+result <- results(dds, cooksCutoff=args$cooks_cutoff, alpha=args$alpha,
+    independentFiltering=args$independent
+)
 result <- result[order(result$padj), ]
 write.table(result, file='diffexp_deseq2.tab', sep='\t', quote=FALSE, col.names=NA)
 # Use file names for the column headers in the count matrix output file


### PR DESCRIPTION
Previously if `independent` field was set to `False` nothing changed and the independent filtering was applied regardless. This PR aims to fix this and retain the old behaviour of using filtering by default (also default in DESeq2).

## Checklist
<!--
Mark an `[x]` for completed items.
-->

* [x] Update CHANGELOG.rst for each commit separately:
  * Pay attention to write entries under the "Unreleased" section.
  * Mark all breaking changes as "**BACKWARD INCOMPATIBLE:**" and put them
    before non-breaking changes.
  * If a commit modifies a feature listed under "Unreleased" section,
    it might be sufficient to modify the existing CHANGELOG entry from previous
    commit(s).
* [x] Bump the process version:
  * **MAJOR version (first number)**: Backward incompatible changes (changes
    that break the api/interface). Examples: renaming the input/output, adding
    mandatory input, removing input/output...
  * **MINOR version (middle number)**: add functionality or changes in a
    backwards-compatible manner. Examples: add output field, add non-mandatory
    input parameter, use a different tool that produces same results...
  * **PATCH version (last number)**: changes/bug fixes that do not affect
    the api/interface. Examples: typo fix, change/add warning messages...
* [x] All inputs are used in process.
* [x] All output fields have a value assigned to them.

