### PR TITLE
Add java memory setting in gatk-genotype-gvcfs

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -25,6 +25,8 @@ Changed
 - Rewrite ``bbduk-single`` and ``bbduk-paired`` processes to Python
 - Rewrite processes ``upload-fastq-single``, ``upload-fastq-paired``,
   ``files-to-fastq-single`` and ``files-to-fastq-paired`` to Python
+- Add java memory setting and remove unused inputs in
+  ``gatk-genotype-gvcfs``
 
 Fixed
 -----

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -147,7 +147,7 @@ FLOW_MANAGER = {
 }
 
 FLOW_PROCESS_MAX_CORES = 1
-FLOW_PROCESS_MAX_MEM = 10240
+FLOW_PROCESS_MAX_MEMORY = 10240
 
 # Don't pull Docker images if set via the environment variable.
 FLOW_DOCKER_DONT_PULL = strtobool(os.environ.get('RESOLWE_DOCKER_DONT_PULL', '0'))


### PR DESCRIPTION
Allocating more memory to Java speeds up the analyisis. Additionaly this removes the two unused parameters.

## Checklist
<!--
Mark an `[x]` for completed items.
-->

* [x] Update CHANGELOG.rst for each commit separately:
  * Pay attention to write entries under the "Unreleased" section.
  * Mark all breaking changes as "**BACKWARD INCOMPATIBLE:**" and put them
    before non-breaking changes.
  * If a commit modifies a feature listed under "Unreleased" section,
    it might be sufficient to modify the existing CHANGELOG entry from previous
    commit(s).
* [x] Bump the process version:
  * **MAJOR version (first number)**: Backward incompatible changes (changes
    that break the api/interface). Examples: renaming the input/output, adding
    mandatory input, removing input/output...
  * **MINOR version (middle number)**: add functionality or changes in a
    backwards-compatible manner. Examples: add output field, add non-mandatory
    input parameter, use a different tool that produces same results...
  * **PATCH version (last number)**: changes/bug fixes that do not affect
    the api/interface. Examples: typo fix, change/add warning messages...
* [x] All inputs are used in process.
* [x] All output fields have a value assigned to them.

