### PR TITLE
Fix automatic species annotation in STAR

### DIFF
--- a/resolwe_bio/processes/alignment/star.py
+++ b/resolwe_bio/processes/alignment/star.py
@@ -68,7 +68,7 @@ class AlignmentStar(Process):
     slug = "alignment-star"
     name = "STAR"
     process_type = "data:alignment:bam:star"
-    version = "3.0.0"
+    version = "3.0.1"
     category = "Align"
     scheduling_class = SchedulingClass.BATCH
     entity = {"type": "sample"}
@@ -230,7 +230,8 @@ class AlignmentStar(Process):
                 required=False,
                 range=[0.0, 1.0],
                 description="Alignment will be output only if its ratio of mismatches to *mapped* "
-                "length is less than or equal to this value (default: 0.3).",
+                "length is less than or equal to this value (default: 0.3). The value should be "
+                "between 0.0 and 1.0.",
             )
 
             out_score_min = IntegerField(
@@ -247,7 +248,7 @@ class AlignmentStar(Process):
                 description="Alignment will be output only if its ratio of mismatches to *read* "
                 "length is less than or equal to this value (default: 1.0). Using 0.04 for "
                 "2x100bp, the max number of mismatches is calculated as 0.04*200=8 for the paired "
-                "read.",
+                "read. The value should be between 0.0 and 1.0.",
             )
 
         class AlignmentOptions:
@@ -421,11 +422,11 @@ class AlignmentStar(Process):
 
         try:
             if (
-                inputs.reads.entity.descriptor["general.species"]
+                inputs.reads.entity.descriptor["general"]["species"]
                 != inputs.genome.output.species
             ):
                 self.warning(
-                    f"Species of reads ({inputs.reads.entity.descriptor['general.species']}) "
+                    f"Species of reads ({inputs.reads.entity.descriptor['general']['species']}) "
                     f"and genome ({inputs.genome.output.species}) do not match."
                 )
         except KeyError:


### PR DESCRIPTION
## Checklist
<!--
Mark an `[x]` for completed items.
-->

* [ ] Update CHANGELOG.rst for each commit separately:
  * Pay attention to write entries under the "Unreleased" section.
  * Mark all breaking changes as "**BACKWARD INCOMPATIBLE:**" and put them
    before non-breaking changes.
  * If a commit modifies a feature listed under "Unreleased" section,
    it might be sufficient to modify the existing CHANGELOG entry from previous
    commit(s).
* [x] Bump the process version:
  * **MAJOR version (first number)**: Backward incompatible changes (changes
    that break the api/interface). Examples: renaming the input/output, adding
    mandatory input, removing input/output...
  * **MINOR version (middle number)**: add functionality or changes in a
    backwards-compatible manner. Examples: add output field, add non-mandatory
    input parameter, use a different tool that produces same results...
  * **PATCH version (last number)**: changes/bug fixes that do not affect
    the api/interface. Examples: typo fix, change/add warning messages...
* [x] All inputs are used in process.
* [x] All output fields have a value assigned to them.
