### PR TITLE
Fix supported extensions in descriptions for Upload expression process

### DIFF
--- a/resolwe_bio/processes/import_data/expressions.py
+++ b/resolwe_bio/processes/import_data/expressions.py
@@ -125,7 +125,7 @@ class UploadExpression(ProcessBio):
     slug = "upload-expression"
     name = "Expression data"
     process_type = "data:expression"
-    version = "2.5.1"
+    version = "2.5.2"
     category = "Import"
     data_name = "{{ exp_name }}"
     scheduling_class = SchedulingClass.BATCH
@@ -151,13 +151,13 @@ class UploadExpression(ProcessBio):
         rc = FileField(
             label="Read counts (raw expression)",
             description="Reads mapped to genomic features (raw count data). "
-            "Supported extensions: .txt.gz (preferred), .tab.* or .txt.*",
+            "Supported extensions: .txt.gz (preferred), .tab.*, .txt.* or .tsv.*",
             required=False,
         )
         exp = FileField(
             label="Normalized expression",
             description="Normalized expression data. Supported extensions: .tab.gz "
-            "(preferred) or .tab.*",
+            "(preferred), .tab.*, .txt.* or .tsv.*",
             required=False,
         )
         exp_name = StringField(


### PR DESCRIPTION
## Checklist
<!--
Mark an `[x]` for completed items.
-->

* [ ] Update CHANGELOG.rst for each commit separately:
  * Pay attention to write entries under the "Unreleased" section.
  * Mark all breaking changes as "**BACKWARD INCOMPATIBLE:**" and put them
    before non-breaking changes.
  * If a commit modifies a feature listed under "Unreleased" section,
    it might be sufficient to modify the existing CHANGELOG entry from previous
    commit(s).
* [x] Bump the process version:
  * **MAJOR version (first number)**: Backward incompatible changes (changes
    that break the api/interface). Examples: renaming the input/output, adding
    mandatory input, removing input/output...
  * **MINOR version (middle number)**: add functionality or changes in a
    backwards-compatible manner. Examples: add output field, add non-mandatory
    input parameter, use a different tool that produces same results...
  * **PATCH version (last number)**: changes/bug fixes that do not affect
    the api/interface. Examples: typo fix, change/add warning messages...
* [x] All inputs are used in process.
* [x] All output fields have a value assigned to them.

