### PR TITLE
Fix ref_seq parameter in gatk-select-variants

### DIFF
--- a/resolwe_bio/processes/variant_calling/gatk_select_variants.py
+++ b/resolwe_bio/processes/variant_calling/gatk_select_variants.py
@@ -22,7 +22,7 @@ class GatkSelectVariants(Process):
     name = "GATK SelectVariants"
     category = "GATK"
     process_type = "data:variants:vcf:selectvariants"
-    version = "1.0.0"
+    version = "1.0.1"
     scheduling_class = SchedulingClass.BATCH
     requirements = {
         "expression-engine": "jinja",
@@ -134,7 +134,7 @@ class GatkSelectVariants(Process):
                     "The genome build information of the provided reference "
                     "sequence file does not match the build of the input VCFs."
                 )
-            args.extend("-R", inputs.advanced_options.ref_seq.output.fasta.path)
+            args.extend(["-R", inputs.advanced_options.ref_seq.output.fasta.path])
 
         if inputs.intervals:
             args.extend(["-L", inputs.intervals.output.bed.path])


### PR DESCRIPTION
## Checklist
<!--
Mark an `[x]` for completed items.
-->

* [ ] Update CHANGELOG.rst for each commit separately:
  * Pay attention to write entries under the "Unreleased" section.
  * Mark all breaking changes as "**BACKWARD INCOMPATIBLE:**" and put them
    before non-breaking changes.
  * If a commit modifies a feature listed under "Unreleased" section,
    it might be sufficient to modify the existing CHANGELOG entry from previous
    commit(s).
* [x] Bump the process version:
  * **MAJOR version (first number)**: Backward incompatible changes (changes
    that break the api/interface). Examples: renaming the input/output, adding
    mandatory input, removing input/output...
  * **MINOR version (middle number)**: add functionality or changes in a
    backwards-compatible manner. Examples: add output field, add non-mandatory
    input parameter, use a different tool that produces same results...
  * **PATCH version (last number)**: changes/bug fixes that do not affect
    the api/interface. Examples: typo fix, change/add warning messages...
* [x] All inputs are used in process.
* [x] All output fields have a value assigned to them.

