### PR TITLE
Change Ensembl-VEP version check in Ensembl-VEP process

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -17,6 +17,7 @@ Added
 Changed
 -------
 - Rewrite ``goenrichment`` process to Python
+- Change Ensembl-VEP version check in ``ensembl-vep`` process
 
 Fixed
 -----

--- a/resolwe_bio/tests/processes/test_variant_calling.py
+++ b/resolwe_bio/tests/processes/test_variant_calling.py
@@ -473,7 +473,8 @@ class VariantCallingTestCase(BioProcessTestCase):
         self.assertEqual(
             vep.process_warning,
             [
-                "The current version of Ensembl-VEP is 104. It is recommended that cache version is also 104"
+                "The current version of Ensembl-VEP is 104. "
+                "It is recommended that cache version is also 104."
             ],
         )
 


### PR DESCRIPTION
## Checklist
<!--
Mark an `[x]` for completed items.
-->

* [x] Update CHANGELOG.rst for each commit separately:
  * Pay attention to write entries under the "Unreleased" section.
  * Mark all breaking changes as "**BACKWARD INCOMPATIBLE:**" and put them
    before non-breaking changes.
  * If a commit modifies a feature listed under "Unreleased" section,
    it might be sufficient to modify the existing CHANGELOG entry from previous
    commit(s).
* [x] Bump the process version:
  * **MAJOR version (first number)**: Backward incompatible changes (changes
    that break the api/interface). Examples: renaming the input/output, adding
    mandatory input, removing input/output...
  * **MINOR version (middle number)**: add functionality or changes in a
    backwards-compatible manner. Examples: add output field, add non-mandatory
    input parameter, use a different tool that produces same results...
  * **PATCH version (last number)**: changes/bug fixes that do not affect
    the api/interface. Examples: typo fix, change/add warning messages...
* [x] All inputs are used in process.
* [x] All output fields have a value assigned to them.

