### PR TITLE
Fix build mismatch error in DESeq2

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -37,6 +37,7 @@ Changed
 
 Fixed
 -----
+- Fix build mismatch error message in ``differentialexpression-deseq2``
 
 
 ===================

--- a/resolwe_bio/processes/differential_expression/deseq.py
+++ b/resolwe_bio/processes/differential_expression/deseq.py
@@ -35,7 +35,7 @@ class Deseq(Process):
     slug = "differentialexpression-deseq2"
     name = "DESeq2"
     process_type = "data:differentialexpression:deseq2"
-    version = "3.4.0"
+    version = "3.4.1"
     category = "Differential Expression"
     scheduling_class = SchedulingClass.BATCH
     persistence = Persistence.CACHED
@@ -174,8 +174,8 @@ class Deseq(Process):
                 )
             if exp.output.build != expressions[0].output.build:
                 self.error(
-                    "Input samples are of different Panel types: "
-                    f"{exp.build} and {expressions[0].build}."
+                    "Input samples are of different Build: "
+                    f"{exp.output.build} and {expressions[0].output.build}."
                 )
             if exp.output.feature_type != expressions[0].output.feature_type:
                 self.error(

--- a/resolwe_bio/tests/processes/test_diff_expression.py
+++ b/resolwe_bio/tests/processes/test_diff_expression.py
@@ -126,6 +126,22 @@ class DiffExpProcessorTestCase(KBBioProcessTestCase):
 
     @with_resolwe_host
     @tag_process("differentialexpression-deseq2")
+    def test_deseq2_build(self):
+        with self.preparation_stage():
+            expression_1 = self.prepare_expression(build="dd-05-2009")
+            expression_2 = self.prepare_expression(build="dd-42-2009")
+
+        inputs = {"case": [expression_1.pk], "control": [expression_2.pk]}
+
+        deseq2 = self.run_process(
+            "differentialexpression-deseq2", inputs, Data.STATUS_ERROR
+        )
+
+        error_msg = ["Input samples are of different Build: dd-42-2009 and dd-05-2009."]
+        self.assertEqual(deseq2.process_error, error_msg)
+
+    @with_resolwe_host
+    @tag_process("differentialexpression-deseq2")
     def test_deseq2_expression_error(self):
         with self.preparation_stage():
             case = self.prepare_expression(


### PR DESCRIPTION
Build field was not accessed correctly since upgrading to a new protocol. This fixes it and adds a test to avoid this in future.

## Checklist
<!--
Mark an `[x]` for completed items.
-->

* [x] Update CHANGELOG.rst for each commit separately:
  * Pay attention to write entries under the "Unreleased" section.
  * Mark all breaking changes as "**BACKWARD INCOMPATIBLE:**" and put them
    before non-breaking changes.
  * If a commit modifies a feature listed under "Unreleased" section,
    it might be sufficient to modify the existing CHANGELOG entry from previous
    commit(s).
* [x] Bump the process version:
  * **MAJOR version (first number)**: Backward incompatible changes (changes
    that break the api/interface). Examples: renaming the input/output, adding
    mandatory input, removing input/output...
  * **MINOR version (middle number)**: add functionality or changes in a
    backwards-compatible manner. Examples: add output field, add non-mandatory
    input parameter, use a different tool that produces same results...
  * **PATCH version (last number)**: changes/bug fixes that do not affect
    the api/interface. Examples: typo fix, change/add warning messages...
* [x] All inputs are used in process.
* [x] All output fields have a value assigned to them.
