### PR TITLE
Rename featureCounts class and fix progress reporting

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -34,10 +34,12 @@ Changed
   endpoints into a single endpoint
 - Rewrite ``goenrichment`` process to Python
 - Change Ensembl-VEP version check in ``ensembl-vep`` process
+- Rename ``featureCounts`` class to ``FeatureCounts``
 
 Fixed
 -----
 - Fix build mismatch error message in ``differentialexpression-deseq2``
+- Fix how ``self.progress`` is called in ``FeatureCounts``
 
 
 ===================

--- a/resolwe_bio/processes/expression/featureCounts.py
+++ b/resolwe_bio/processes/expression/featureCounts.py
@@ -168,7 +168,7 @@ def expression_to_storage(rc_input, rc_output):
     return rc_output
 
 
-class featureCounts(ProcessBio):
+class FeatureCounts(ProcessBio):
     """Quantify sequencing reads aligned to genomic features.
 
     featureCounts is a highly efficient general-purpose read summarization
@@ -200,7 +200,7 @@ class featureCounts(ProcessBio):
         },
     }
     data_name = "{{ aligned_reads|sample_name|default('?') }}"
-    version = "5.0.4"
+    version = "5.1.0"
     process_type = "data:expression:featurecounts"
     category = "Quantify"
     entity = {
@@ -651,7 +651,7 @@ class featureCounts(ProcessBio):
         if int(Cmd["samtools"]["view"]["-c", "-f", "1", bam_file]().strip()) == 0:
             paired_end = False
 
-        self.progress = 0.05
+        self.progress(0.05)
 
         # set strandedness
         if inputs.assay_type == "auto":
@@ -745,7 +745,7 @@ class featureCounts(ProcessBio):
         else:
             strandedness = STRANDEDNESS_CODES[inputs.assay_type]
 
-        self.progress = 0.1
+        self.progress(0.1)
 
         # Replace empty gene_id entries in annotation file if source is UCSC
         annotation_file = inputs.annotation.output.annot.path
@@ -873,7 +873,7 @@ class featureCounts(ProcessBio):
         if return_code:
             self.error("Error while running featureCounts.")
 
-        self.progress = 0.8
+        self.progress(0.8)
 
         raw_counts = "rc.txt"
         tpm = "tpm.txt"
@@ -897,7 +897,7 @@ class featureCounts(ProcessBio):
         if return_code:
             self.error("Error while normalizing counts using rnanorm.")
 
-        self.progress = 0.9
+        self.progress(0.9)
 
         # prepare the expression set outputs
         feature_ids = pd.read_csv(
@@ -922,7 +922,7 @@ class featureCounts(ProcessBio):
             outfile_name=f"{name}_expressions",
         )
 
-        self.progress = 0.95
+        self.progress(0.95)
 
         # rename and compress the expression files
         rename_columns_and_compress(raw_counts, f"{name}_rc.tab.gz")


### PR DESCRIPTION
featureCounts class is renamed to FeatureClass to be PEP compliant.
Calling the progress (bar) is now fixed.

## Checklist

* [x] Update CHANGELOG.rst for each commit separately:
  * Pay attention to write entries under the "Unreleased" section.
  * Mark all breaking changes as "**BACKWARD INCOMPATIBLE:**" and put them
    before non-breaking changes.
  * If a commit modifies a feature listed under "Unreleased" section,
    it might be sufficient to modify the existing CHANGELOG entry from previous
    commit(s).
* [x] Bump the process version:
  * **MAJOR version (first number)**: Backward incompatible changes (changes
    that break the api/interface). Examples: renaming the input/output, adding
    mandatory input, removing input/output...
  * **MINOR version (middle number)**: add functionality or changes in a
    backwards-compatible manner. Examples: add output field, add non-mandatory
    input parameter, use a different tool that produces same results...
  * **PATCH version (last number)**: changes/bug fixes that do not affect
    the api/interface. Examples: typo fix, change/add warning messages...
* [x] All inputs are used in process.
* [x] All output fields have a value assigned to them.
