### PR TITLE
Fix output handling in GO Enrichment Analysis process

### DIFF
--- a/resolwe_bio/processes/go_enrichment/go.py
+++ b/resolwe_bio/processes/go_enrichment/go.py
@@ -1,8 +1,6 @@
 """Gene Ontology Enrichment Analysis."""
 import tempfile
 
-from plumbum import TEE
-
 from resolwe.process import (
     Cmd,
     DataField,
@@ -24,7 +22,7 @@ class GOEnrichmentAnalysis(ProcessBio):
     slug = "goenrichment"
     name = "GO Enrichment analysis"
     process_type = "data:goea"
-    version = "3.5.0"
+    version = "3.5.1"
     category = "Other"
     data_name = 'GO Enrichment analysis for {{genes|join(", ")|default("?")}}'
     scheduling_class = SchedulingClass.INTERACTIVE
@@ -132,15 +130,7 @@ class GOEnrichmentAnalysis(ProcessBio):
                 input_genes.name,
             ]
 
-            return_code, stdout, stderr = Cmd["processor"][args] & TEE(retcode=None)
-            if return_code:
-                print(stderr)
-                self.error(
-                    "Error occurred with processor. See standard output for more details."
-                )
-
-            with open("terms.json", "w") as f:
-                f.write(stdout + " ")
+            (Cmd["processor"][args] > "terms.json")()
 
         outputs.source = inputs.gaf.output.source
         outputs.species = inputs.gaf.output.species


### PR DESCRIPTION

* [ ] Update CHANGELOG.rst for each commit separately:
  * Pay attention to write entries under the "Unreleased" section.
  * Mark all breaking changes as "**BACKWARD INCOMPATIBLE:**" and put them
    before non-breaking changes.
  * If a commit modifies a feature listed under "Unreleased" section,
    it might be sufficient to modify the existing CHANGELOG entry from previous
    commit(s).
* [x] Bump the process version:
  * **MAJOR version (first number)**: Backward incompatible changes (changes
    that break the api/interface). Examples: renaming the input/output, adding
    mandatory input, removing input/output...
  * **MINOR version (middle number)**: add functionality or changes in a
    backwards-compatible manner. Examples: add output field, add non-mandatory
    input parameter, use a different tool that produces same results...
  * **PATCH version (last number)**: changes/bug fixes that do not affect
    the api/interface. Examples: typo fix, change/add warning messages...
* [x] All inputs are used in process.
* [x] All output fields have a value assigned to them.

