### PR TITLE
Fix disabled option for Chimeric reads options in General RNA-seq pipeline

### DIFF
--- a/.scripts/check_large_files.py
+++ b/.scripts/check_large_files.py
@@ -22,7 +22,7 @@ def find_large_files(directory, limit):
     for f in sorted(os.listdir(directory)):
         file_path = os.path.join(directory, f)
         size = os.path.getsize(file_path)
-        if size > limit * 1024 ** 2:
+        if size > limit * 1024**2:
             large_files.append(file_path)
     return large_files
 

--- a/resolwe_bio/processes/import_data/seq_reads.py
+++ b/resolwe_bio/processes/import_data/seq_reads.py
@@ -284,15 +284,12 @@ class UploadFastqSingle(Process):
                     "Recoding input reads from Phred64 encoding to Phred33 encoding."
                 )
                 Path(f"{reads_name}.fastq.gz").rename("input_reads.fastq.gz")
-                return_code, _, stderr = (
-                    Cmd["TrimmomaticSE"][
-                        "-phred64",
-                        "input_reads.fastq.gz",
-                        "reformated.fastq.gz",
-                        "TOPHRED33",
-                    ]
-                    & TEE(retcode=None)
-                )
+                return_code, _, stderr = Cmd["TrimmomaticSE"][
+                    "-phred64",
+                    "input_reads.fastq.gz",
+                    "reformated.fastq.gz",
+                    "TOPHRED33",
+                ] & TEE(retcode=None)
                 if return_code:
                     print(stderr)
                     self.error("Error while running TrimmomaticSE.")
@@ -488,15 +485,12 @@ class UploadFastqPaired(Process):
             if encoding == "Illumina 1.5" or encoding == "Illumina 1.3":
                 print("Recoding input reads from Phred64 encoding to Phred33 encoding.")
                 Path(f"{reads_name}.fastq.gz").rename("input_reads.fastq.gz")
-                return_code, _, stderr = (
-                    Cmd["TrimmomaticSE"][
-                        "-phred64",
-                        "input_reads.fastq.gz",
-                        "reformated.fastq.gz",
-                        "TOPHRED33",
-                    ]
-                    & TEE(retcode=None)
-                )
+                return_code, _, stderr = Cmd["TrimmomaticSE"][
+                    "-phred64",
+                    "input_reads.fastq.gz",
+                    "reformated.fastq.gz",
+                    "TOPHRED33",
+                ] & TEE(retcode=None)
                 if return_code:
                     print(stderr)
                     self.error("Recoding of input reads failed.")
@@ -628,15 +622,12 @@ class FilesToFastqSingle(Process):
                     "Recoding input reads from Phred64 encoding to Phred33 encoding."
                 )
                 Path(f"{reads_name}.fastq.gz").rename("input_reads.fastq.gz")
-                return_code, _, stderr = (
-                    Cmd["TrimmomaticSE"][
-                        "-phred64",
-                        "input_reads.fastq.gz",
-                        "reformated.fastq.gz",
-                        "TOPHRED33",
-                    ]
-                    & TEE(retcode=None)
-                )
+                return_code, _, stderr = Cmd["TrimmomaticSE"][
+                    "-phred64",
+                    "input_reads.fastq.gz",
+                    "reformated.fastq.gz",
+                    "TOPHRED33",
+                ] & TEE(retcode=None)
                 if return_code:
                     print(stderr)
                     self.error("Error while running TrimmomaticSE.")
@@ -833,15 +824,12 @@ class FilesToFastqPaired(Process):
             if encoding == "Illumina 1.5" or encoding == "Illumina 1.3":
                 print("Recoding input reads from Phred64 encoding to Phred33 encoding.")
                 Path(f"{reads_name}.fastq.gz").rename("input_reads.fastq.gz")
-                return_code, _, stderr = (
-                    Cmd["TrimmomaticSE"][
-                        "-phred64",
-                        "input_reads.fastq.gz",
-                        "reformated.fastq.gz",
-                        "TOPHRED33",
-                    ]
-                    & TEE(retcode=None)
-                )
+                return_code, _, stderr = Cmd["TrimmomaticSE"][
+                    "-phred64",
+                    "input_reads.fastq.gz",
+                    "reformated.fastq.gz",
+                    "TOPHRED33",
+                ] & TEE(retcode=None)
                 if return_code:
                     print(stderr)
                     self.error("Recoding of input reads failed.")

--- a/resolwe_bio/processes/import_data/sra_file.py
+++ b/resolwe_bio/processes/import_data/sra_file.py
@@ -292,15 +292,12 @@ class ImportSraSingle(Process):
             if encoding == "Illumina 1.5\n" or encoding == "Illumina 1.3\n":
                 print("Recoding input reads from Phred64 encoding to Phred33 encoding.")
                 Path(f"{reads_name}.fastq.gz").rename("input_reads.fastq.gz")
-                return_code, _, _ = (
-                    Cmd["TrimmomaticSE"][
-                        "-phred64",
-                        "input_reads.fastq.gz",
-                        "reformated.fastq.gz",
-                        "TOPHRED33",
-                    ]
-                    & TEE(retcode=None)
-                )
+                return_code, _, _ = Cmd["TrimmomaticSE"][
+                    "-phred64",
+                    "input_reads.fastq.gz",
+                    "reformated.fastq.gz",
+                    "TOPHRED33",
+                ] & TEE(retcode=None)
                 if return_code:
                     self.error("Recoding of input reads failed.")
                 Path("reformated.fastq.gz").rename(f"{reads_name}.fastq.gz")
@@ -486,15 +483,12 @@ class ImportSraPaired(Process):
             if encoding == "Illumina 1.5\n" or encoding == "Illumina 1.3\n":
                 print("Recoding input reads from Phred64 encoding to Phred33 encoding.")
                 Path(f"{reads_name}.fastq.gz").rename("input_reads.fastq.gz")
-                return_code, _, _ = (
-                    Cmd["TrimmomaticSE"][
-                        "-phred64",
-                        "input_reads.fastq.gz",
-                        "reformated.fastq.gz",
-                        "TOPHRED33",
-                    ]
-                    & TEE(retcode=None)
-                )
+                return_code, _, _ = Cmd["TrimmomaticSE"][
+                    "-phred64",
+                    "input_reads.fastq.gz",
+                    "reformated.fastq.gz",
+                    "TOPHRED33",
+                ] & TEE(retcode=None)
                 if return_code:
                     self.error("Recoding of input reads failed.")
                 Path("reformated.fastq.gz").rename(f"{reads_name}.fastq.gz")

--- a/resolwe_bio/processes/workflows/bbduk_star_featurecounts_qc.py
+++ b/resolwe_bio/processes/workflows/bbduk_star_featurecounts_qc.py
@@ -43,7 +43,7 @@ class WorkflowBBDukStarFcQC(Process):
         "expression-engine": "jinja",
     }
     data_name = "{{ reads|sample_name|default('?') }}"
-    version = "5.0.0"
+    version = "5.0.1"
     process_type = "data:workflow:rnaseq:featurecounts:qc"
     category = "Pipeline"
 
@@ -214,7 +214,7 @@ class WorkflowBBDukStarFcQC(Process):
                 chim_segment_min = IntegerField(
                     label="Minimum length of chimeric segment [--chimSegmentMin]",
                     default=20,
-                    disabled="!detect_chimeric.chimeric",
+                    disabled="!alignment.chimeric_reads.chimeric",
                 )
 
             class TranscriptOutputOptions:

--- a/resolwe_bio/tools/spikein_pairwise.py
+++ b/resolwe_bio/tools/spikein_pairwise.py
@@ -186,7 +186,7 @@ def plot_scatter(scatter, zero, nonzero, exp_type):
         y=0.9,
         s="\n".join(
             [
-                "$R^2$ = {}".format(round(r_value ** 2, 2)),
+                "$R^2$ = {}".format(round(r_value**2, 2)),
                 "{} / {} transcripts not detected".format(
                     len(zero), len(zero) + len(nonzero)
                 ),


### PR DESCRIPTION

* [ ] Update CHANGELOG.rst for each commit separately:
  * Pay attention to write entries under the "Unreleased" section.
  * Mark all breaking changes as "**BACKWARD INCOMPATIBLE:**" and put them
    before non-breaking changes.
  * If a commit modifies a feature listed under "Unreleased" section,
    it might be sufficient to modify the existing CHANGELOG entry from previous
    commit(s).
* [x] Bump the process version:
  * **MAJOR version (first number)**: Backward incompatible changes (changes
    that break the api/interface). Examples: renaming the input/output, adding
    mandatory input, removing input/output...
  * **MINOR version (middle number)**: add functionality or changes in a
    backwards-compatible manner. Examples: add output field, add non-mandatory
    input parameter, use a different tool that produces same results...
  * **PATCH version (last number)**: changes/bug fixes that do not affect
    the api/interface. Examples: typo fix, change/add warning messages...
* [x] All inputs are used in process.
* [x] All output fields have a value assigned to them.

