### PR TITLE
Fix LISTENER_CONNECTION settings

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -40,6 +40,7 @@ Fixed
 - Fix ``--cl-config`` input option in MultiQC process. Use
   ``resolwebio/common:3.0.1`` Docker image with updated MultiQC
   configuration file to omit parsing the unwanted ``tmp`` folder
+- Fix LISTENER_CONNECTION settings to work on Mac
 
 
 ===================

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -5,6 +5,7 @@ Django settings for running tests for Resolwe package.
 
 import os
 import re
+import sys
 from distutils.util import strtobool  # pylint: disable=import-error,no-name-in-module
 
 PROJECT_ROOT = os.path.abspath(os.path.dirname(__file__))
@@ -100,14 +101,24 @@ REDIS_CONNECTION = {
     'db': int(os.environ.get('RESOLWE_REDIS_DATABASE', 0)),
 }
 LISTENER_CONNECTION = {
-    "hosts": {
-        "docker": "172.17.0.1",
-    },
+    # Keys in the hosts dictionary are workload connector names. Currently
+    # supported are 'local', 'kubertenes', 'celery' and 'slurm'.
+    "hosts": {"local": "172.17.0.1"},
     "port": int(os.environ.get("RESOLWE_LISTENER_SERVICE_PORT", 53893)),
     "min_port": 50000,
     "max_port": 60000,
     "protocol": "tcp",
 }
+
+# The IP address where listener is available from the communication container.
+# The setting is a dictionary where key is the name of the workload connector.
+COMMUNICATION_CONTAINER_LISTENER_CONNECTION = {"local": "172.17.0.1"}
+
+# Settings in OSX/Windows are different since Docker runs in a virtual machine.
+if sys.platform == "darwin":
+    LISTENER_CONNECTION["hosts"]["local"] = "0.0.0.0"
+    COMMUNICATION_CONTAINER_LISTENER_CONNECTION = {"local": "127.0.0.1"}
+
 FLOW_EXECUTOR = {
     'NAME': 'resolwe.flow.executors.docker',
     # XXX: Change to a stable resolwe image when it will include all the required tools


### PR DESCRIPTION

* [ ] Update CHANGELOG.rst for each commit separately:
  * Pay attention to write entries under the "Unreleased" section.
  * Mark all breaking changes as "**BACKWARD INCOMPATIBLE:**" and put them
    before non-breaking changes.
  * If a commit modifies a feature listed under "Unreleased" section,
    it might be sufficient to modify the existing CHANGELOG entry from previous
    commit(s).
* [ ] Bump the process version:
  * **MAJOR version (first number)**: Backward incompatible changes (changes
    that break the api/interface). Examples: renaming the input/output, adding
    mandatory input, removing input/output...
  * **MINOR version (middle number)**: add functionality or changes in a
    backwards-compatible manner. Examples: add output field, add non-mandatory
    input parameter, use a different tool that produces same results...
  * **PATCH version (last number)**: changes/bug fixes that do not affect
    the api/interface. Examples: typo fix, change/add warning messages...
* [ ] All inputs are used in process.
* [ ] All output fields have a value assigned to them.

