### PR TITLE
Add Java memory setting to processes MarkDuplicates, BQSR and GATK SplitNCigarReads

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -33,6 +33,7 @@ Changed
   ``resolwebio/rnaseq:6.0.0`` to match those from
   ``resolwebio/common:3.0.1`` Docker image and update genome-tools to
   1.6.2 in ``resolwebio/rnaseq:6.0.0`` Docker image
+- Add Java memory settings to processes ``bqsr`` and ``markduplicates``
 
 Fixed
 -----

--- a/resolwe_bio/tests/processes/test_reads_filtering.py
+++ b/resolwe_bio/tests/processes/test_reads_filtering.py
@@ -463,6 +463,10 @@ class ReadsFilteringProcessorTestCase(BioProcessTestCase):
                 "bigwig_binsize": 50,
                 "bigwig_timeout": 30,
             },
+            "advanced": {
+                "java_gc_threads": 3,
+                "max_heap_size": 10,
+            },
         }
         removed_md = self.run_process("markduplicates", md_inputs)
 
@@ -584,7 +588,11 @@ class ReadsFilteringProcessorTestCase(BioProcessTestCase):
                 "reference": reference.id,
                 "known_sites": [i.id for i in ks_dbsnp],
                 "intervals": intervals.id,
-                "advanced": {"use_original_qualities": True},
+                "advanced": {
+                    "use_original_qualities": True,
+                    "java_gc_threads": 3,
+                    "max_heap_size": 10,
+                },
             }
             bqsr = self.run_process("bqsr", bqsr_inputs)
             self.assertFileExists(bqsr, "bam")
@@ -748,6 +756,10 @@ class ReadsFilteringProcessorTestCase(BioProcessTestCase):
             {
                 "bam": bam.id,
                 "ref_seq": ref_seq.id,
+                "advanced": {
+                    "java_gc_threads": 3,
+                    "max_heap_size": 10,
+                },
             },
         )
 


### PR DESCRIPTION

* [ ] Update CHANGELOG.rst for each commit separately:
  * Pay attention to write entries under the "Unreleased" section.
  * Mark all breaking changes as "**BACKWARD INCOMPATIBLE:**" and put them
    before non-breaking changes.
  * If a commit modifies a feature listed under "Unreleased" section,
    it might be sufficient to modify the existing CHANGELOG entry from previous
    commit(s).
* [x] Bump the process version:
  * **MAJOR version (first number)**: Backward incompatible changes (changes
    that break the api/interface). Examples: renaming the input/output, adding
    mandatory input, removing input/output...
  * **MINOR version (middle number)**: add functionality or changes in a
    backwards-compatible manner. Examples: add output field, add non-mandatory
    input parameter, use a different tool that produces same results...
  * **PATCH version (last number)**: changes/bug fixes that do not affect
    the api/interface. Examples: typo fix, change/add warning messages...
* [x] All inputs are used in process.
* [x] All output fields have a value assigned to them.

