### PR TITLE
Fix handling missing relations in merge-sample processes

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -46,6 +46,8 @@ Fixed
 - Set ``Persistence`` property to ``TEMP`` for processes
   ``find-similar`` and ``clustering-hierarchical-etc``
 - Fix input schema in pipeline ``workflow-rnaseq-variantcalling``
+- Fail gracefully when no relation labels are found in
+  ``merge-fastq-single`` and ``merge-fastq-paired`` processes
 
 
 ===================

--- a/resolwe_bio/tests/processes/test_support_processors.py
+++ b/resolwe_bio/tests/processes/test_support_processors.py
@@ -1387,6 +1387,13 @@ re-save-file lane_attributes "${NAME}".txt
                 category="Replicate",
             )
 
+            treatment_group = Relation.objects.create(
+                contributor=self.contributor,
+                collection=self.collection,
+                type=rel_type_group,
+                category="Treatment",
+            )
+
             RelationPartition.objects.create(
                 relation=replicate_group,
                 entity=reads_single_1.entity,
@@ -1420,6 +1427,24 @@ re-save-file lane_attributes "${NAME}".txt
             "fastq",
             [os.path.join("merge-fastq", "output", "reads_merged.fastq.gz")],
             compression="gzip",
+        )
+
+        RelationPartition.objects.create(
+            relation=treatment_group,
+            entity=reads_single_1.entity,
+            label="treatment 1",
+        )
+
+        inputs = {"reads": [reads_single_1.pk, reads_single_2.pk]}
+        merge_process = self.run_process("merge-fastq-single", inputs)
+
+        relation_warn = (
+            "Sample reads.fastq.gz has defined Treatment relation. "
+            "Samples will only be merged based on Replicate relations."
+        )
+        self.assertEqual(
+            merge_process.process_warning,
+            [relation_warn],
         )
 
         inputs = {"reads": [reads_paired_1.pk, reads_paired_2.pk]}


### PR DESCRIPTION
This PR should improve error messages for the wrong type of relations or inputs without them. However, this process can still produce unexpected results. For example, a user could select the wrong type of relations and also have all replicate relations defined, which would merge based on replicate relations and not the selected type. The latest push adds a warning for multiple relations defined on a data object.

## Checklist
<!--
Mark an `[x]` for completed items.
-->

* [x] Update CHANGELOG.rst for each commit separately:
  * Pay attention to write entries under the "Unreleased" section.
  * Mark all breaking changes as "**BACKWARD INCOMPATIBLE:**" and put them
    before non-breaking changes.
  * If a commit modifies a feature listed under "Unreleased" section,
    it might be sufficient to modify the existing CHANGELOG entry from previous
    commit(s).
* [x] Bump the process version:
  * **MAJOR version (first number)**: Backward incompatible changes (changes
    that break the api/interface). Examples: renaming the input/output, adding
    mandatory input, removing input/output...
  * **MINOR version (middle number)**: add functionality or changes in a
    backwards-compatible manner. Examples: add output field, add non-mandatory
    input parameter, use a different tool that produces same results...
  * **PATCH version (last number)**: changes/bug fixes that do not affect
    the api/interface. Examples: typo fix, change/add warning messages...
* [x] All inputs are used in process.
* [x] All output fields have a value assigned to them.
