### PR TITLE
Add openpyxl to resolwebio/common Docker image

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -16,6 +16,8 @@ Added
 
 Changed
 -------
+- Add ``openpyxl`` Python package in ``resolwebio/common:3.1.0`` Docker
+  image
 
 Fixed
 -----

--- a/resolwe_bio/docker_images/common/packages-python3.txt
+++ b/resolwe_bio/docker_images/common/packages-python3.txt
@@ -70,6 +70,8 @@ sphinxcontrib-devhelp==1.0.2 --hash=sha256:8165223f9a335cc1af7ffe1ed31d2871f3252
 # Pandas dependencies.
 python-dateutil==2.8.1 --hash=sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a
 pytz==2021.1 --hash=sha256:eb10ce3e7736052ed3623d49975ce333bcd712c7bb19a58b9e2089d4057d0798
+openpyxl==3.0.9 --hash=sha256:8f3b11bd896a95468a4ab162fc4fcd260d46157155d1f8bfaabb99d88cfcf79f
+et_xmlfile==1.1.0 --hash=sha256:a2ba85d1d6a74ef63837eed693bcb89c3f752169b0e3e7ae5b16ca5e1b3deada
 
 # Bioservices dependencies.
 gevent==21.1.2 --hash=sha256:520cc2a029a9eef436e4e56b007af7859315cafa21937d43c1d5269f12f2c981


### PR DESCRIPTION
This adds `openpyxl` which is required by `pandas.read_excel()`. This will allow us to remove orange Docker image (BIOINF-74).

## Checklist
<!--
Mark an `[x]` for completed items.
-->

* [x] Update CHANGELOG.rst for each commit separately:
  * Pay attention to write entries under the "Unreleased" section.
  * Mark all breaking changes as "**BACKWARD INCOMPATIBLE:**" and put them
    before non-breaking changes.
  * If a commit modifies a feature listed under "Unreleased" section,
    it might be sufficient to modify the existing CHANGELOG entry from previous
    commit(s).
* [ ] Bump the process version:
  * **MAJOR version (first number)**: Backward incompatible changes (changes
    that break the api/interface). Examples: renaming the input/output, adding
    mandatory input, removing input/output...
  * **MINOR version (middle number)**: add functionality or changes in a
    backwards-compatible manner. Examples: add output field, add non-mandatory
    input parameter, use a different tool that produces same results...
  * **PATCH version (last number)**: changes/bug fixes that do not affect
    the api/interface. Examples: typo fix, change/add warning messages...
* [ ] All inputs are used in process.
* [ ] All output fields have a value assigned to them.