### PR TITLE
Use resolwebio/common Docker image for metadata upload

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -23,6 +23,8 @@ Changed
   ``alleyoop-snpeval``, ``alleyoop-summary``, ``alleyoop-utr-rates``,
   ``slam-count``, ``slamdunk-all-paired`` the workflow
   ``workflow-slamdunk-paired`` and related code in ``multiqc``
+- Use ``resolwebio/common:3.1.0`` in ``upload-metadata-unique`` and
+  ``upload-metadata`` processes
 
 Fixed
 -----

--- a/resolwe_bio/processes/import_data/metadata.py
+++ b/resolwe_bio/processes/import_data/metadata.py
@@ -70,13 +70,13 @@ class UploadMetadataUnique(Process):
     slug = "upload-metadata-unique"
     name = "Metadata table (one-to-one)"
     process_type = "data:metadata:unique"
-    version = "1.0.0"
+    version = "1.1.0"
     category = "Import"
     scheduling_class = SchedulingClass.BATCH
     requirements = {
         "expression-engine": "jinja",
         "executor": {
-            "docker": {"image": "public.ecr.aws/s4q6j6e8/resolwebio/orange:2.0.0"}
+            "docker": {"image": "public.ecr.aws/s4q6j6e8/resolwebio/common:3.1.0"}
         },
         "resources": {
             "cores": 1,
@@ -158,13 +158,13 @@ class UploadMetadata(Process):
     slug = "upload-metadata"
     name = "Metadata table"
     process_type = "data:metadata"
-    version = "1.0.0"
+    version = "1.1.0"
     category = "Import"
     scheduling_class = SchedulingClass.BATCH
     requirements = {
         "expression-engine": "jinja",
         "executor": {
-            "docker": {"image": "public.ecr.aws/s4q6j6e8/resolwebio/orange:2.0.0"}
+            "docker": {"image": "public.ecr.aws/s4q6j6e8/resolwebio/common:3.1.0"}
         },
         "resources": {
             "cores": 1,


### PR DESCRIPTION
Requires `public.ecr.aws/s4q6j6e8/resolwebio/common:3.1.0` which replaces Orange Docker image (BIOINF-74).

## Checklist
<!--
Mark an `[x]` for completed items.
-->

* [x] Update CHANGELOG.rst for each commit separately:
  * Pay attention to write entries under the "Unreleased" section.
  * Mark all breaking changes as "**BACKWARD INCOMPATIBLE:**" and put them
    before non-breaking changes.
  * If a commit modifies a feature listed under "Unreleased" section,
    it might be sufficient to modify the existing CHANGELOG entry from previous
    commit(s).
* [x] Bump the process version:
  * **MAJOR version (first number)**: Backward incompatible changes (changes
    that break the api/interface). Examples: renaming the input/output, adding
    mandatory input, removing input/output...
  * **MINOR version (middle number)**: add functionality or changes in a
    backwards-compatible manner. Examples: add output field, add non-mandatory
    input parameter, use a different tool that produces same results...
  * **PATCH version (last number)**: changes/bug fixes that do not affect
    the api/interface. Examples: typo fix, change/add warning messages...
* [] All inputs are used in process.
* [ ] All output fields have a value assigned to them.