### PR TITLE
Fix fragment length and memory issues in macs2-callpeak

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -26,6 +26,8 @@ Changed
 - Use ``resolwebio/chipseq:6.1.0`` in ``chipqc`` process
 - Use ``resolwebio/methylation_arrays:1.1.0`` in the
   ``methylation-array-sesame`` process
+- Improve error reporting for invalid fragment length estimates and fix
+  memory issues with MarkDuplicates in ``macs2-callpeak`` process
 
 Fixed
 -----

--- a/resolwe_bio/tests/processes/test_chipseq.py
+++ b/resolwe_bio/tests/processes/test_chipseq.py
@@ -247,6 +247,25 @@ class ChipSeqProcessorTestCase(BioProcessTestCase):
         err_msg = ["No paired-end reads were detected but BAMPE format was selected."]
         self.assertEqual(macs_paired_err.process_error, err_msg)
 
+        # Test negative fragment length estimate error.
+        inputs = {
+            "case": paired_end.id,
+            "tagalign": True,
+            "settings": {
+                "pvalue": 0.05,
+                "duplicates": "all",
+                "bedgraph": True,
+            },
+        }
+
+        macs_fraglen_err = self.run_process("macs2-callpeak", inputs, Data.STATUS_ERROR)
+        err_msg = [
+            "Failed to estimate fragment length because the top estimate is negative. Top three "
+            "estimates were: -370,125,-280. Please manually define the Extension size [--extsize] "
+            "parameter."
+        ]
+        self.assertEqual(macs_fraglen_err.process_error, err_msg)
+
     @skipUnlessLargeFiles("rose2_case.bam", "rose2_control.bam")
     @tag_process("rose2")
     def test_rose2(self):


### PR DESCRIPTION
## Checklist
<!--
Mark an `[x]` for completed items.
-->

* [x] Update CHANGELOG.rst for each commit separately:
  * Pay attention to write entries under the "Unreleased" section.
  * Mark all breaking changes as "**BACKWARD INCOMPATIBLE:**" and put them
    before non-breaking changes.
  * If a commit modifies a feature listed under "Unreleased" section,
    it might be sufficient to modify the existing CHANGELOG entry from previous
    commit(s).
* [x] Bump the process version:
  * **MAJOR version (first number)**: Backward incompatible changes (changes
    that break the api/interface). Examples: renaming the input/output, adding
    mandatory input, removing input/output...
  * **MINOR version (middle number)**: add functionality or changes in a
    backwards-compatible manner. Examples: add output field, add non-mandatory
    input parameter, use a different tool that produces same results...
  * **PATCH version (last number)**: changes/bug fixes that do not affect
    the api/interface. Examples: typo fix, change/add warning messages...
* [x] All inputs are used in process.
* [x] All output fields have a value assigned to them.
