### PR TITLE
Bump memory requirements in xengsort-index

### DIFF
--- a/resolwe_bio/processes/reads_processing/xengsort.py
+++ b/resolwe_bio/processes/reads_processing/xengsort.py
@@ -76,12 +76,12 @@ class XengsortIndex(Process):
         },
         "resources": {
             "cores": 4,
-            "memory": 16384,
+            "memory": 32768,
         },
     }
     category = "Xenograft processing"
     data_name = "Xengsort index"
-    version = "1.0.0"
+    version = "1.0.1"
     scheduling_class = SchedulingClass.BATCH
     persistence = Persistence.CACHED
 


### PR DESCRIPTION
The process had insufficient memory for creating a typical index with two fasta files for host and graft organisms. 

## Checklist
<!--
Mark an `[x]` for completed items.
-->

* [ ] Update CHANGELOG.rst for each commit separately:
  * Pay attention to write entries under the "Unreleased" section.
  * Mark all breaking changes as "**BACKWARD INCOMPATIBLE:**" and put them
    before non-breaking changes.
  * If a commit modifies a feature listed under "Unreleased" section,
    it might be sufficient to modify the existing CHANGELOG entry from previous
    commit(s).
* [x] Bump the process version:
  * **MAJOR version (first number)**: Backward incompatible changes (changes
    that break the api/interface). Examples: renaming the input/output, adding
    mandatory input, removing input/output...
  * **MINOR version (middle number)**: add functionality or changes in a
    backwards-compatible manner. Examples: add output field, add non-mandatory
    input parameter, use a different tool that produces same results...
  * **PATCH version (last number)**: changes/bug fixes that do not affect
    the api/interface. Examples: typo fix, change/add warning messages...
* [ ] All inputs are used in process.
* [ ] All output fields have a value assigned to them.
