### PR TITLE
Fixes for the ChIP-seq pipeline

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -21,6 +21,8 @@ Changed
 
 Fixed
 -----
+- Fix ChIPQC plot rendering in ``multiqc`` process for samples
+  containing file extensions in their name
 
 
 ===================

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -23,6 +23,8 @@ Fixed
 -----
 - Fix ChIPQC plot rendering in ``multiqc`` process for samples
   containing file extensions in their name
+- Update SRA url for fetching experiment metadata in ``geo-import``
+  process
 
 
 ===================

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -16,6 +16,8 @@ Added
 
 Changed
 -------
+- Use all three fragment length estimates before failing due to negative
+  the estimate in ``macs2-callpeak`` process
 
 Fixed
 -----

--- a/resolwe_bio/tests/processes/test_chipseq.py
+++ b/resolwe_bio/tests/processes/test_chipseq.py
@@ -258,13 +258,13 @@ class ChipSeqProcessorTestCase(BioProcessTestCase):
             },
         }
 
-        macs_fraglen_err = self.run_process("macs2-callpeak", inputs, Data.STATUS_ERROR)
-        err_msg = [
-            "Failed to estimate fragment length because the top estimate is negative. Top three "
-            "estimates were: -370,125,-280. Please manually define the Extension size [--extsize] "
-            "parameter."
+        macs_fraglen = self.run_process("macs2-callpeak", inputs)
+        warning_msg = [
+            "SPP estimated negative fragment length which can not be used by "
+            "MACS2. Using 125 from the top estimates (-370,125,-280) as "
+            "the estimate of extension size [--extsize] for MACS2."
         ]
-        self.assertEqual(macs_fraglen_err.process_error, err_msg)
+        self.assertEqual(macs_fraglen.process_warning, warning_msg)
 
     @skipUnlessLargeFiles("rose2_case.bam", "rose2_control.bam")
     @tag_process("rose2")

--- a/resolwe_bio/tests/processes/test_support_processors.py
+++ b/resolwe_bio/tests/processes/test_support_processors.py
@@ -775,13 +775,13 @@ re-save-file case_prepeak_qc "${NAME}".txt
                     "src": os.path.join("chipqc", "output", "PeakProfile_mqc.png"),
                 },
             )
-            set_sample_name(chipqc, "ChipQC test")
+            set_sample_name(chipqc, "ChipQC test.fastq.gz")
 
             postpeak_qc_report = self.run_process(
                 peak_qc.slug,
                 {"src": os.path.join("chipqc", "input", "postpeak_qc_report.txt")},
             )
-            set_sample_name(postpeak_qc_report, "ChipQC test")
+            set_sample_name(postpeak_qc_report, "ChipQC test.fastq.gz")
 
         multiqc = self.run_process(
             "multiqc",


### PR DESCRIPTION
- Consider all three fragment length estimates to save compute resources and minimise errors in MACS2
- Use only the estimates where `estimate > 0` as expected by MACS2
- Avoid using sample names for storing ChIPQC plots in the MultiQC process to avoid missing plots in the report. This was a consequence of file name cleaning (removal of some suffixes) which led to duplicated plot ids.

## Checklist
<!--
Mark an `[x]` for completed items.
-->

* [x] Update CHANGELOG.rst for each commit separately:
  * Pay attention to write entries under the "Unreleased" section.
  * Mark all breaking changes as "**BACKWARD INCOMPATIBLE:**" and put them
    before non-breaking changes.
  * If a commit modifies a feature listed under "Unreleased" section,
    it might be sufficient to modify the existing CHANGELOG entry from previous
    commit(s).
* [x] Bump the process version:
  * **MAJOR version (first number)**: Backward incompatible changes (changes
    that break the api/interface). Examples: renaming the input/output, adding
    mandatory input, removing input/output...
  * **MINOR version (middle number)**: add functionality or changes in a
    backwards-compatible manner. Examples: add output field, add non-mandatory
    input parameter, use a different tool that produces same results...
  * **PATCH version (last number)**: changes/bug fixes that do not affect
    the api/interface. Examples: typo fix, change/add warning messages...
* [x] All inputs are used in process.
* [x] All output fields have a value assigned to them.
