### PR TITLE
Fix sample naming in the MultiQC report

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -21,6 +21,8 @@ Changed
 Fixed
 -----
 - Bump version of ``rnaseq-vc-preprocess`` process
+- Fix sample naming in ``multiqc`` process to avoid leaving out data in
+  the MultiQC report
 
 
 ===================

--- a/resolwe_bio/tests/processes/test_support_processors.py
+++ b/resolwe_bio/tests/processes/test_support_processors.py
@@ -712,11 +712,15 @@ re-save-file duplicates_report "${NAME}".txt
                     "language": "bash",
                     "program": r"""
 re-import {{ src.file_temp|default(src.file) }} {{ src.file }} "png" "png" 0.1 extract
-re-save-file ccplot "${NAME}".png
-re-save-file coverage_histogram "${NAME}".png
+cp "${NAME}".png CCPlot_mqc.png
+cp "${NAME}".png CoverageHistogramPlot_mqc.png
+cp "${NAME}".png Rip_mqc.png
+cp "${NAME}".png Rap_mqc.png
+re-save-file ccplot CCPlot_mqc.png
+re-save-file coverage_histogram CoverageHistogramPlot_mqc.png
 re-save-file peak_profile "${NAME}".png
-re-save-file peaks_barplot "${NAME}".png
-re-save-file peaks_density_plot "${NAME}".png
+re-save-file peaks_barplot Rip_mqc.png
+re-save-file peaks_density_plot Rap_mqc.png
 """,
                 },
             )


### PR DESCRIPTION
This attempts to fix the sample name cleaning bug in MultiQC related to [BUG-817](https://genialis.atlassian.net/browse/BUG-817).

General Statistics before:
<img width="1580" alt="image" src="https://user-images.githubusercontent.com/10329834/194074602-7ce8d79e-6d5c-4279-ba0f-d6d7ef09a64d.png">

General Statistics after:
<img width="1580" alt="image" src="https://user-images.githubusercontent.com/10329834/194074704-1d6904c0-e48f-4835-8a98-cda5e125a159.png">
There is an additional row for each pair file/lane/etc.

## Checklist
<!--
Mark an `[x]` for completed items.
-->

* [x] Update CHANGELOG.rst for each commit separately:
  * Pay attention to write entries under the "Unreleased" section.
  * Mark all breaking changes as "**BACKWARD INCOMPATIBLE:**" and put them
    before non-breaking changes.
  * If a commit modifies a feature listed under "Unreleased" section,
    it might be sufficient to modify the existing CHANGELOG entry from previous
    commit(s).
* [x] Bump the process version:
  * **MAJOR version (first number)**: Backward incompatible changes (changes
    that break the api/interface). Examples: renaming the input/output, adding
    mandatory input, removing input/output...
  * **MINOR version (middle number)**: add functionality or changes in a
    backwards-compatible manner. Examples: add output field, add non-mandatory
    input parameter, use a different tool that produces same results...
  * **PATCH version (last number)**: changes/bug fixes that do not affect
    the api/interface. Examples: typo fix, change/add warning messages...
* [ ] All inputs are used in process.
* [ ] All output fields have a value assigned to them.

<!--
Read the following guidelines and remove them before opening the pull request.
-->
