### PR TITLE
Symlink individual Salmon outputs in the MultiQC process

### DIFF
--- a/resolwe_bio/processes/support_processors/multiqc.py
+++ b/resolwe_bio/processes/support_processors/multiqc.py
@@ -1,6 +1,7 @@
 """Prepare MultiQC report."""
 import json
 import os
+from pathlib import Path
 
 import pandas as pd
 import yaml
@@ -332,7 +333,7 @@ class MultiQC(Process):
     }
     category = "Other"
     data_name = "MultiQC report"
-    version = "1.16.0"
+    version = "1.16.1"
 
     class Input:
         """Input fields to process MultiQC."""
@@ -533,7 +534,10 @@ class MultiQC(Process):
                 create_symlink(d.output.summary.path, os.path.join(sample_dir, name))
 
             elif d.process.type == "data:expression:salmon:":
-                create_symlink(d.output.salmon_output.path, sample_dir)
+                # Symlink files/dirs without the parent directory to
+                # attach it to the same sample in the general summary.
+                for out_file in Path(d.output.salmon_output.path).iterdir():
+                    create_symlink(str(out_file), str(Path(sample_dir) / out_file.name))
                 # Strandedness report might not exist in legacy Salmon objects
                 process_strand_report_file(d, lib_type_samples, lib_type_reports)
 


### PR DESCRIPTION
In a recent MultiQC fix we moved QoRTs files to the sample directory to report those statistics in the same row as others. This fix does the same for salmon outputs. 

The outputs used to be a separate category:
![image](https://user-images.githubusercontent.com/10329834/195100671-38e5a86c-84e4-483a-8c39-30d4c4b4e184.png)


## Checklist
<!--
Mark an `[x]` for completed items.
-->

* [ ] Update CHANGELOG.rst for each commit separately:
  * Pay attention to write entries under the "Unreleased" section.
  * Mark all breaking changes as "**BACKWARD INCOMPATIBLE:**" and put them
    before non-breaking changes.
  * If a commit modifies a feature listed under "Unreleased" section,
    it might be sufficient to modify the existing CHANGELOG entry from previous
    commit(s).
* [x] Bump the process version:
  * **MAJOR version (first number)**: Backward incompatible changes (changes
    that break the api/interface). Examples: renaming the input/output, adding
    mandatory input, removing input/output...
  * **MINOR version (middle number)**: add functionality or changes in a
    backwards-compatible manner. Examples: add output field, add non-mandatory
    input parameter, use a different tool that produces same results...
  * **PATCH version (last number)**: changes/bug fixes that do not affect
    the api/interface. Examples: typo fix, change/add warning messages...
* [ ] All inputs are used in process.
* [ ] All output fields have a value assigned to them.

<!--
Read the following guidelines and remove them before opening the pull request.
-->
