### PR TITLE
Remove group nesting for QC fields in General descriptor schema

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -20,6 +20,8 @@ Added
 
 Changed
 -------
+- Remove group nesting for QC fields in ``general`` descriptor
+  schema
 
 Fixed
 -----

--- a/resolwe_bio/descriptors/unified-descriptor.yml
+++ b/resolwe_bio/descriptors/unified-descriptor.yml
@@ -1,7 +1,7 @@
 - slug: general
   name: General descriptor schema
   description: General descriptor schema.
-  version: 2.0.3
+  version: 2.1.0
   schema:
     - name: general
       label: General information
@@ -39,24 +39,21 @@
           label: Description
           type: basic:string
           required: false
-        - name: qc
-          label: Quality check
-          group:
-            - name: status
-              label: Status
-              type: basic:string
-              required: false
-              choices:
-                - label: Pass
-                  value: PASS
-                - label: Warning
-                  value: WARNING
-                - label: Fail
-                  value: FAIL
-            - name: message
-              label: Message
-              type: basic:string
-              required: false
+        - name: qc_status
+          label: QC/Status
+          type: basic:string
+          required: false
+          choices:
+            - label: Pass
+              value: PASS
+            - label: Warning
+              value: WARNING
+            - label: Fail
+              value: FAIL
+        - name: qc_message
+          label: QC/Message
+          type: basic:string
+          required: false
     - name: non_clinical_information
       label: Non-clinical information
       group:


### PR DESCRIPTION

* [x] Update CHANGELOG.rst for each commit separately:
  * Pay attention to write entries under the "Unreleased" section.
  * Mark all breaking changes as "**BACKWARD INCOMPATIBLE:**" and put them
    before non-breaking changes.
  * If a commit modifies a feature listed under "Unreleased" section,
    it might be sufficient to modify the existing CHANGELOG entry from previous
    commit(s).
* [x] Bump the process version:
  * **MAJOR version (first number)**: Backward incompatible changes (changes
    that break the api/interface). Examples: renaming the input/output, adding
    mandatory input, removing input/output...
  * **MINOR version (middle number)**: add functionality or changes in a
    backwards-compatible manner. Examples: add output field, add non-mandatory
    input parameter, use a different tool that produces same results...
  * **PATCH version (last number)**: changes/bug fixes that do not affect
    the api/interface. Examples: typo fix, change/add warning messages...
* [x] All inputs are used in process.
* [x] All output fields have a value assigned to them.
