### PR TITLE
Fix the check for genome builds of inputs in process snpEff

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -26,6 +26,7 @@ Changed
 Fixed
 -----
 - Enable ordering on knowledge-base endpoints
+- Fix the check for genome builds of inputs in process ``snpeff``
 
 
 ===================

--- a/resolwe_bio/processes/variant_calling/snpeff.py
+++ b/resolwe_bio/processes/variant_calling/snpeff.py
@@ -46,7 +46,7 @@ class SnpEff(Process):
     }
     category = "Other"
     data_name = "Annotated variants (SnpEff)"
-    version = "1.0.0"
+    version = "1.0.1"
     scheduling_class = SchedulingClass.BATCH
     persistence = Persistence.CACHED
 
@@ -140,7 +140,7 @@ class SnpEff(Process):
         filtered_variants = "filtered_variants.vcf"
         extracted_variants = "extracted_variants.vcf"
 
-        if inputs.variants.output.build != inputs.database[:6]:
+        if not inputs.variants.output.build.startswith(inputs.database[:6]):
             self.error(
                 "Genome build for the input variants file and "
                 "SnpEff database should be the same. Input variants file is "
@@ -156,7 +156,7 @@ class SnpEff(Process):
 
         if inputs.dbsnp:
 
-            if inputs.dbsnp.output.build != inputs.database[:6]:
+            if not inputs.dbsnp.output.build.startswith(inputs.database[:6]):
                 self.error(
                     "Genome build for the DBSNP file and used database "
                     "should be the same. DBSNP file is based on "

--- a/resolwe_bio/tests/processes/test_variant_calling.py
+++ b/resolwe_bio/tests/processes/test_variant_calling.py
@@ -216,7 +216,7 @@ class VariantCallingTestCase(BioProcessTestCase):
                 {
                     "src": input_folder / "filtered_snpeff.vcf.gz",
                     "species": "Homo sapiens",
-                    "build": "GRCh38",
+                    "build": "GRCh38_ens100",
                 },
             )
             dbsnp_rna = self.run_process(
@@ -225,6 +225,14 @@ class VariantCallingTestCase(BioProcessTestCase):
                     "src": input_folder / "dbsnp.vcf.gz",
                     "species": "Homo sapiens",
                     "build": "GRCh37",
+                },
+            )
+            dbsnp_rna_38 = self.run_process(
+                "upload-variants-vcf",
+                {
+                    "src": input_folder / "dbsnp.vcf.gz",
+                    "species": "Homo sapiens",
+                    "build": "GRCh38",
                 },
             )
             genes = self.run_process(
@@ -252,6 +260,15 @@ class VariantCallingTestCase(BioProcessTestCase):
             "GRCh37, while snpEff database is based on "
             "GRCh38.",
         )
+        snpeff = self.run_process(
+            "snpeff",
+            {
+                "variants": variants_rna.id,
+                "database": "GRCh38.99",
+                "dbsnp": dbsnp_rna_38.id,
+            },
+        )
+        self.assertFields(snpeff, "build", "GRCh38_ens100")
 
         snpeff_filtering = self.run_process(
             "snpeff",


### PR DESCRIPTION
## Checklist
<!--
Mark an `[x]` for completed items.
-->

* [x] Update CHANGELOG.rst for each commit separately:
  * Pay attention to write entries under the "Unreleased" section.
  * Mark all breaking changes as "**BACKWARD INCOMPATIBLE:**" and put them
    before non-breaking changes.
  * If a commit modifies a feature listed under "Unreleased" section,
    it might be sufficient to modify the existing CHANGELOG entry from previous
    commit(s).
* [x] Bump the process version:
  * **MAJOR version (first number)**: Backward incompatible changes (changes
    that break the api/interface). Examples: renaming the input/output, adding
    mandatory input, removing input/output...
  * **MINOR version (middle number)**: add functionality or changes in a
    backwards-compatible manner. Examples: add output field, add non-mandatory
    input parameter, use a different tool that produces same results...
  * **PATCH version (last number)**: changes/bug fixes that do not affect
    the api/interface. Examples: typo fix, change/add warning messages...
* [x] All inputs are used in process.
* [x] All output fields have a value assigned to them.
