### PR TITLE
Fix SRA import to accept 0 as minimum read length

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -21,6 +21,8 @@ Changed
 
 Fixed
 -----
+- Fix ``min_read_len`` parameter to pass zero values in
+  ``import-sra-single``, ``import-sra-paired``, ``import-sra``
 
 
 ===================

--- a/resolwe_bio/processes/import_data/sra_file.py
+++ b/resolwe_bio/processes/import_data/sra_file.py
@@ -52,7 +52,7 @@ class ImportSra(Process):
     slug = "import-sra"
     name = "SRA data"
     process_type = "data:sra"
-    version = "1.5.0"
+    version = "1.5.1"
     category = "Import"
     scheduling_class = SchedulingClass.BATCH
     persistence = Persistence.TEMP
@@ -126,9 +126,7 @@ class ImportSra(Process):
             process_inputs["advanced"]["min_spot_id"] = inputs.advanced.min_spot_id
         if inputs.advanced.max_spot_id:
             process_inputs["advanced"]["max_spot_id"] = inputs.advanced.max_spot_id
-        if inputs.advanced.min_read_len:
-            process_inputs["advanced"]["min_read_len"] = inputs.advanced.min_read_len
-        if inputs.advanced.min_read_len:
+        if inputs.advanced.min_read_len is not None:
             process_inputs["advanced"]["min_read_len"] = inputs.advanced.min_read_len
 
         self.run_process(process_slug, process_inputs)
@@ -146,7 +144,7 @@ class ImportSraSingle(Process):
     slug = "import-sra-single"
     name = "SRA data (single-end)"
     process_type = "data:reads:fastq:single"
-    version = "1.6.0"
+    version = "1.6.1"
     category = "Import"
     scheduling_class = SchedulingClass.BATCH
     persistence = Persistence.RAW
@@ -220,7 +218,7 @@ class ImportSraSingle(Process):
                 cmd = cmd["--minSpotId"][inputs.advanced.min_spot_id]
             if inputs.advanced.max_spot_id:
                 cmd = cmd["--maxSpotId"][inputs.advanced.max_spot_id]
-            if inputs.advanced.min_read_len:
+            if inputs.advanced.min_read_len is not None:
                 cmd = cmd["--minReadLen"][inputs.advanced.min_read_len]
             if inputs.advanced.clip:
                 cmd = cmd["--clip"]
@@ -318,7 +316,7 @@ class ImportSraPaired(Process):
     slug = "import-sra-paired"
     name = "SRA data (paired-end)"
     process_type = "data:reads:fastq:paired"
-    version = "1.6.0"
+    version = "1.6.1"
     category = "Import"
     scheduling_class = SchedulingClass.BATCH
     persistence = Persistence.RAW
@@ -408,7 +406,7 @@ class ImportSraPaired(Process):
                 cmd = cmd["--minSpotId"][inputs.advanced.min_spot_id]
             if inputs.advanced.max_spot_id:
                 cmd = cmd["--maxSpotId"][inputs.advanced.max_spot_id]
-            if inputs.advanced.min_read_len:
+            if inputs.advanced.min_read_len is not None:
                 cmd = cmd["--minReadLen"][inputs.advanced.min_read_len]
             if inputs.advanced.clip:
                 cmd = cmd["--clip"]


### PR DESCRIPTION
SRA processed would not allow setting minimum read length to 0. Paired-end files with 0-length reads would have those filtered out and FASTQ validation would raise an error.

## Checklist
<!--
Mark an `[x]` for completed items.
-->

* [x] Update CHANGELOG.rst for each commit separately:
  * Pay attention to write entries under the "Unreleased" section.
  * Mark all breaking changes as "**BACKWARD INCOMPATIBLE:**" and put them
    before non-breaking changes.
  * If a commit modifies a feature listed under "Unreleased" section,
    it might be sufficient to modify the existing CHANGELOG entry from previous
    commit(s).
* [x] Bump the process version:
  * **MAJOR version (first number)**: Backward incompatible changes (changes
    that break the api/interface). Examples: renaming the input/output, adding
    mandatory input, removing input/output...
  * **MINOR version (middle number)**: add functionality or changes in a
    backwards-compatible manner. Examples: add output field, add non-mandatory
    input parameter, use a different tool that produces same results...
  * **PATCH version (last number)**: changes/bug fixes that do not affect
    the api/interface. Examples: typo fix, change/add warning messages...
* [ ] All inputs are used in process.
* [ ] All output fields have a value assigned to them.
