### PR TITLE
Prevent BBduk from stopping when lanes exceed cores

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -23,6 +23,8 @@ Fixed
 -----
 - Fix ``min_read_len`` parameter to pass zero values in
   ``import-sra-single``, ``import-sra-paired``, ``import-sra``
+- Prevent ``bbduk-single`` and ``bbduk-paired`` processes from stopping
+  when the number of lanes exceeds the number of available cores
 
 
 ===================

--- a/resolwe_bio/processes/reads_processing/bbduk.py
+++ b/resolwe_bio/processes/reads_processing/bbduk.py
@@ -149,7 +149,7 @@ class BBDukSingle(Process):
     slug = "bbduk-single"
     name = "BBDuk (single-end)"
     process_type = "data:reads:fastq:single:bbduk"
-    version = "3.1.0"
+    version = "3.1.1"
     category = "FASTQ processing"
     data_name = "{{ reads|name|default('?') }}"
     scheduling_class = SchedulingClass.BATCH
@@ -633,11 +633,16 @@ class BBDukSingle(Process):
             args.append(
                 f"threads={int(self.requirements.resources.cores//num_of_lanes)}"
             )
+            n_jobs = num_of_lanes
         else:
-            self.error(
+            self.warning(
                 f"There are more sequencing lanes ({num_of_lanes}) than there are "
-                f"available cores ({self.requirements.resources.cores}). "
+                f"available cores ({self.requirements.resources.cores}). For the "
+                "most optimal performance, use at least the same number of lanes "
+                "and cores."
             )
+            args.append("threads=1")
+            n_jobs = self.requirements.resources.cores
 
         if inputs.reference.sequences:
             args.append(f"ref={input_references}")
@@ -665,7 +670,7 @@ class BBDukSingle(Process):
             barcodes = ",".join(barcodes)
             args.append(f"barcodes={barcodes}")
 
-        process_outputs = Parallel(n_jobs=num_of_lanes)(
+        process_outputs = Parallel(n_jobs=n_jobs)(
             run_bbduk(input_reads=input_set, bbduk_inputs=args)
             for input_set in input_reads
         )
@@ -738,7 +743,7 @@ class BBDukPaired(Process):
     slug = "bbduk-paired"
     name = "BBDuk (paired-end)"
     process_type = "data:reads:fastq:paired:bbduk"
-    version = "3.1.0"
+    version = "3.1.1"
     category = "FASTQ processing"
     data_name = "{{ reads|name|default('?') }}"
     scheduling_class = SchedulingClass.BATCH
@@ -1261,11 +1266,16 @@ class BBDukPaired(Process):
             args.append(
                 f"threads={int(self.requirements.resources.cores//num_of_lanes)}"
             )
+            n_jobs = num_of_lanes
         else:
-            self.error(
+            self.warning(
                 f"There are more sequencing lanes ({num_of_lanes}) than there are "
-                f"available cores ({self.requirements.resources.cores}). "
+                f"available cores ({self.requirements.resources.cores}). For the "
+                "most optimal performance, use at least the same number of lanes "
+                "and cores."
             )
+            args.append("threads=1")
+            n_jobs = self.requirements.resources.cores
 
         if inputs.reference.sequences:
             args.append(f"ref={input_references}")
@@ -1293,7 +1303,7 @@ class BBDukPaired(Process):
             barcodes = ",".join(barcodes)
             args.append(f"barcodes={barcodes}")
 
-        process_outputs = Parallel(n_jobs=num_of_lanes)(
+        process_outputs = Parallel(n_jobs=n_jobs)(
             run_bbduk(input_reads=input_set, bbduk_inputs=args, paired_end=True)
             for input_set in input_reads
         )


### PR DESCRIPTION
This prevents the process from raising an error out when there are more lanes than available cores. 

## Checklist
<!--
Mark an `[x]` for completed items.
-->

* [x] Update CHANGELOG.rst for each commit separately:
  * Pay attention to write entries under the "Unreleased" section.
  * Mark all breaking changes as "**BACKWARD INCOMPATIBLE:**" and put them
    before non-breaking changes.
  * If a commit modifies a feature listed under "Unreleased" section,
    it might be sufficient to modify the existing CHANGELOG entry from previous
    commit(s).
* [x] Bump the process version:
  * **MAJOR version (first number)**: Backward incompatible changes (changes
    that break the api/interface). Examples: renaming the input/output, adding
    mandatory input, removing input/output...
  * **MINOR version (middle number)**: add functionality or changes in a
    backwards-compatible manner. Examples: add output field, add non-mandatory
    input parameter, use a different tool that produces same results...
  * **PATCH version (last number)**: changes/bug fixes that do not affect
    the api/interface. Examples: typo fix, change/add warning messages...
* [ ] All inputs are used in process.
* [ ] All output fields have a value assigned to them.