### PR TITLE
Fix SRA parameters to pass zero values in geo-import

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -19,6 +19,7 @@ Changed
 
 Fixed
 -----
+- Fix SRA parameters to pass zero values in ``geo-import`` workflow
 
 
 ===================

--- a/resolwe_bio/processes/workflows/geo_import.py
+++ b/resolwe_bio/processes/workflows/geo_import.py
@@ -189,7 +189,7 @@ class GeoImport(Process):
         },
     }
     data_name = "{{ gse_accession }}"
-    version = "2.6.0"
+    version = "2.6.1"
     process_type = "data:geo"
     category = "Import"
     scheduling_class = SchedulingClass.BATCH
@@ -263,15 +263,11 @@ class GeoImport(Process):
                 "clip": inputs.advanced.clip,
                 "aligned": inputs.advanced.aligned,
                 "unaligned": inputs.advanced.unaligned,
+                "min_spot_id": inputs.advanced.min_spot_id,
+                "max_spot_id": inputs.advanced.max_spot_id,
+                "min_read_len": inputs.advanced.min_read_len,
             },
         }
-
-        if inputs.advanced.min_spot_id:
-            process_inputs["advanced"]["min_spot_id"] = inputs.advanced.min_spot_id
-        if inputs.advanced.max_spot_id:
-            process_inputs["advanced"]["max_spot_id"] = inputs.advanced.max_spot_id
-        if inputs.advanced.min_read_len:
-            process_inputs["advanced"]["min_read_len"] = inputs.advanced.min_read_len
 
         sample_info = {}
         for name, gsm in gse.gsms.items():


### PR DESCRIPTION
## Checklist
<!--
Mark an `[x]` for completed items.
-->

* [x] Update CHANGELOG.rst for each commit separately:
  * Pay attention to write entries under the "Unreleased" section.
  * Mark all breaking changes as "**BACKWARD INCOMPATIBLE:**" and put them
    before non-breaking changes.
  * If a commit modifies a feature listed under "Unreleased" section,
    it might be sufficient to modify the existing CHANGELOG entry from previous
    commit(s).
* [x] Bump the process version:
  * **MAJOR version (first number)**: Backward incompatible changes (changes
    that break the api/interface). Examples: renaming the input/output, adding
    mandatory input, removing input/output...
  * **MINOR version (middle number)**: add functionality or changes in a
    backwards-compatible manner. Examples: add output field, add non-mandatory
    input parameter, use a different tool that produces same results...
  * **PATCH version (last number)**: changes/bug fixes that do not affect
    the api/interface. Examples: typo fix, change/add warning messages...
* [ ] All inputs are used in process.
* [ ] All output fields have a value assigned to them.
