### PR TITLE
Report assigned reads count by STAR quantification

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -16,6 +16,10 @@ Added
 
 Changed
 -------
+- Change ``star-quantification`` process to include number of assigned reads
+  in the summary report
+- Change ``MultiQC`` report to include assigned reads from ``star-quantification``
+  process
 
 Fixed
 -----

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -20,6 +20,8 @@ Changed
   in the summary report
 - Change ``MultiQC`` report to include assigned reads from ``star-quantification``
   process
+- Change ``workflow-bbduk-star-qc`` workflow to include assigned reads
+  by ``star-quantification`` in ``MultiQC`` report
 
 Fixed
 -----

--- a/resolwe_bio/processes/expression/star_quantification.py
+++ b/resolwe_bio/processes/expression/star_quantification.py
@@ -45,13 +45,20 @@ def prepare_gene_counts(infile, outfile, summary, strandedness):
         dtype={"Geneid": str, 0: int, 1: int, 2: int},
     )
     # Raw counts for genes
-    exp.iloc[4:][[strandedness]].to_csv(
+    gene_rc_df = exp.iloc[4:][[strandedness]]
+    gene_rc_df.to_csv(
         outfile,
         index_label="FEATURE_ID",
         header=["EXPRESSION"],
         sep="\t",
     )
-    exp.iloc[:4][[strandedness]].to_csv(
+
+    assigned_reads = gene_rc_df.sum()
+    assigned_reads = int(assigned_reads.values)
+    summary_df = exp.iloc[:4][[strandedness]]
+    summary_df.loc["N_assigned"] = assigned_reads
+
+    summary_df.to_csv(
         summary,
         index_label="Status",
         header=["Read count"],
@@ -189,7 +196,7 @@ class NormalizeSTARGeneQuantification(ProcessBio):
         },
     }
     data_name = "{{ aligned_reads|name|default('?') }}"
-    version = "1.1.0"
+    version = "1.2.0"
     process_type = "data:expression:star"
     category = "Quantify"
     entity = {

--- a/resolwe_bio/processes/workflows/bbduk_star.py
+++ b/resolwe_bio/processes/workflows/bbduk_star.py
@@ -41,7 +41,7 @@ class WorkflowSTAR(Process):
         "expression-engine": "jinja",
     }
     data_name = "{{ reads|name|default('?') }}"
-    version = "1.1.0"
+    version = "1.2.0"
     entity = {
         "type": "sample",
     }
@@ -638,7 +638,7 @@ class WorkflowSTAR(Process):
         if inputs.cdna_index:
             input_quant["cdna_index"] = inputs.cdna_index
 
-        Data.create(
+        counts = Data.create(
             process=BioProcess.get_latest(slug="star-quantification"),
             input=input_quant,
             name=f"Quantified ({inputs.reads.name})",
@@ -719,6 +719,7 @@ class WorkflowSTAR(Process):
                 inputs.reads,
                 preprocessing,
                 alignment,
+                counts,
                 downsampling,
                 alignment_qc_rrna,
                 alignment_qc_globin,

--- a/resolwe_bio/tests/files/test_star/output/exp_summary.txt
+++ b/resolwe_bio/tests/files/test_star/output/exp_summary.txt
@@ -3,3 +3,4 @@ N_unmapped	18
 N_multimapping	5
 N_noFeature	315
 N_ambiguous	0
+N_assigned	34

--- a/resolwe_bio/tests/processes/test_support_processors.py
+++ b/resolwe_bio/tests/processes/test_support_processors.py
@@ -461,6 +461,15 @@ class SupportProcessorTestCase(KBBioProcessTestCase):
                 {
                     "genome": star_index.id,
                     "reads": paired_reads.id,
+                    "gene_counts": True,
+                },
+            )
+
+            star_quantification = self.run_process(
+                "star-quantification",
+                {
+                    "aligned_reads": star_alignment.id,
+                    "annotation": annotation.id,
                 },
             )
 
@@ -506,6 +515,7 @@ class SupportProcessorTestCase(KBBioProcessTestCase):
                     filtered_reads.id,
                     bam_samtools.id,
                     star_alignment.id,
+                    star_quantification.id,
                     samtools_idxstats.id,
                     qorts_report.id,
                     rnaseqc_report.id,


### PR DESCRIPTION
## Checklist

* [X] Update CHANGELOG.rst for each commit separately:
  * Pay attention to write entries under the "Unreleased" section.
  * Mark all breaking changes as "**BACKWARD INCOMPATIBLE:**" and put them
    before non-breaking changes.
  * If a commit modifies a feature listed under "Unreleased" section,
    it might be sufficient to modify the existing CHANGELOG entry from previous
    commit(s).
* [X] Bump the process version:
  * **MAJOR version (first number)**: Backward incompatible changes (changes
    that break the api/interface). Examples: renaming the input/output, adding
    mandatory input, removing input/output...
  * **MINOR version (middle number)**: add functionality or changes in a
    backwards-compatible manner. Examples: add output field, add non-mandatory
    input parameter, use a different tool that produces same results...
  * **PATCH version (last number)**: changes/bug fixes that do not affect
    the api/interface. Examples: typo fix, change/add warning messages...
* [X] All inputs are used in process.
* [X] All output fields have a value assigned to them.