### PR TITLE
Fix experimental model annotation in geo-import

### DIFF
--- a/resolwe_bio/processes/workflows/geo_import.py
+++ b/resolwe_bio/processes/workflows/geo_import.py
@@ -127,12 +127,12 @@ def construct_annotation(metadata, sample_name):
         annotation["general.description"] = sample_metadata["description"]
 
     if "cell line" in metadata.columns:
-        annotation["biospecimen_information.biosample_type"] = "cell_line"
+        annotation["biospecimen_information.experimental_model"] = "cell_line"
         annotation["cell_line_information.cell_line_name"] = sample_metadata[
             "cell line"
         ]
     elif "tissue" in metadata.columns:
-        annotation["biospecimen_information.biosample_type"] = "tissue"
+        annotation["biospecimen_information.experimental_model"] = "tissue"
 
     if "source_name_ch1" in metadata.columns:
         annotation["biospecimen_information.source"] = sample_metadata[
@@ -223,7 +223,7 @@ class GeoImport(Process):
         },
     }
     data_name = "{{ gse_accession }}"
-    version = "2.7.0"
+    version = "2.7.1"
     process_type = "data:geo"
     category = "Import"
     scheduling_class = SchedulingClass.BATCH

--- a/resolwe_bio/tests/workflows/test_geo_import.py
+++ b/resolwe_bio/tests/workflows/test_geo_import.py
@@ -39,7 +39,7 @@ class GeoImportTestCase(BioProcessTestCase, LiveServerTestCase):
         )
 
         AnnotationField.objects.create(
-            name="biosample_type",
+            name="experimental_model",
             sort_order=1,
             group=biospecimen_group,
             type=AnnotationType.STRING.value,
@@ -171,7 +171,7 @@ class GeoImportTestCase(BioProcessTestCase, LiveServerTestCase):
         self.assertAnnotation(sample, "general.description", "ING5 knockdown")
 
         self.assertAnnotation(
-            sample, "biospecimen_information.biosample_type", "cell_line"
+            sample, "biospecimen_information.experimental_model", "cell_line"
         )
         self.assertAnnotation(sample, "biospecimen_information.source", "HepG2 cells")
 
@@ -336,7 +336,7 @@ class GeoImportTestCase(BioProcessTestCase, LiveServerTestCase):
 
         # biospecimen_information
         self.assertAnnotation(
-            sample, "biospecimen_information.biosample_type", "cell_line"
+            sample, "biospecimen_information.experimental_model", "cell_line"
         )
         self.assertAnnotation(
             sample, "biospecimen_information.source", "GM12878 (B-Lymphocyte) LCL"


### PR DESCRIPTION
## Checklist
<!--
Mark an `[x]` for completed items.
-->

* [x] Update CHANGELOG.rst for each commit separately:
  * Pay attention to write entries under the "Unreleased" section.
  * Mark all breaking changes as "**BACKWARD INCOMPATIBLE:**" and put them
    before non-breaking changes.
  * If a commit modifies a feature listed under "Unreleased" section,
    it might be sufficient to modify the existing CHANGELOG entry from previous
    commit(s).
* [x] Bump the process version:
  * **MAJOR version (first number)**: Backward incompatible changes (changes
    that break the api/interface). Examples: renaming the input/output, adding
    mandatory input, removing input/output...
  * **MINOR version (middle number)**: add functionality or changes in a
    backwards-compatible manner. Examples: add output field, add non-mandatory
    input parameter, use a different tool that produces same results...
  * **PATCH version (last number)**: changes/bug fixes that do not affect
    the api/interface. Examples: typo fix, change/add warning messages...
* [ ] All inputs are used in process.
* [ ] All output fields have a value assigned to them.
