### PR TITLE
Fix handling of multiple instances of STAR aligner input in the MultiQC process

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -27,6 +27,8 @@ Changed
 
 Fixed
 -----
+- Fix handling of multiple instances of STAR aligner input in the 
+  ``multiqc`` process
 
 
 ===================


### PR DESCRIPTION
This fixes cases of overwritten STAR aligner reports when parsing data by MultiQC. When the same (or similar) inputs are given, the solution is to store the reports in separate folders. This produces additional lines in General stats table
<img width="1495" alt="Screenshot 2024-06-11 at 13 11 57" src="https://github.com/genialis/resolwe-bio/assets/2889622/e0e898c7-6681-4127-8d0f-24cf5ed0cc2a">

