### PR TITLE
Fix coercing the number of threads to int in the ``xengsort-index`` process

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -28,6 +28,8 @@ Fixed
 - Fix the ``mutations-table`` process so that only a single variant instance
   is reported for each variant in ``variants`` application. The process now
   also correcly handles the ``depth`` field reporting.
+- Fix that the number of used threads is correctly coerced to integer in 
+  ``xengsort-index``
 
 
 ===================

--- a/resolwe_bio/processes/reads_processing/xengsort.py
+++ b/resolwe_bio/processes/reads_processing/xengsort.py
@@ -72,7 +72,7 @@ class XengsortIndex(Process):
     }
     category = "Xenograft processing"
     data_name = "Xengsort index"
-    version = "2.0.0"
+    version = "2.0.1"
     scheduling_class = SchedulingClass.BATCH
     persistence = Persistence.CACHED
 
@@ -258,9 +258,9 @@ class XengsortIndex(Process):
             "--fill",
             inputs.advanced.fill,
             "--threads-read",
-            max(int(self.requirements.resources.cores) / 2, 1),
+            max(int(self.requirements.resources.cores / 2), 1),
             "--threads-split",
-            max(int(self.requirements.resources.cores) / 2, 1),
+            max(int(self.requirements.resources.cores / 2), 1),
         ]
 
         if inputs.advanced.aligned_cache:


### PR DESCRIPTION
Come hell or high water, ensure that the number of threads is always an integer.

## Checklist
<!--
Mark an `[x]` for completed items.
-->

* [x] Update CHANGELOG.rst for each commit separately:
  * Pay attention to write entries under the "Unreleased" section.
  * Mark all breaking changes as "**BACKWARD INCOMPATIBLE:**" and put them
    before non-breaking changes.
  * If a commit modifies a feature listed under "Unreleased" section,
    it might be sufficient to modify the existing CHANGELOG entry from previous
    commit(s).
* [x] Bump the process version:
  * **MAJOR version (first number)**: Backward incompatible changes (changes
    that break the api/interface). Examples: renaming the input/output, adding
    mandatory input, removing input/output...
  * **MINOR version (middle number)**: add functionality or changes in a
    backwards-compatible manner. Examples: add output field, add non-mandatory
    input parameter, use a different tool that produces same results...
  * **PATCH version (last number)**: changes/bug fixes that do not affect
    the api/interface. Examples: typo fix, change/add warning messages...
* [x] All inputs are used in process.
* [x] All output fields have a value assigned to them.
