### PR TITLE
Fix and add more choices to --chimOutType parameter in STAR

### DIFF
--- a/resolwe_bio/processes/alignment/star.py
+++ b/resolwe_bio/processes/alignment/star.py
@@ -59,7 +59,7 @@ class AlignmentStar(Process):
     slug = "alignment-star"
     name = "STAR"
     process_type = "data:alignment:bam:star"
-    version = "5.2.0"
+    version = "5.3.0"
     category = "Align"
     scheduling_class = SchedulingClass.BATCH
     entity = {"type": "sample"}
@@ -162,10 +162,13 @@ class AlignmentStar(Process):
                 label="Chimeric output type [--chimOutType]",
                 default="SeparateSAMold",
                 choices=[
-                    ("WithinBam", "WithinBam"),
+                    ("WithinBAM", "WithinBAM"),
+                    ("WithinBAM HardClip", "WithinBAM HardClip"),
+                    ("WithinBAM SoftClip", "WithinBAM SoftClip"),
                     ("SeparateSAMold", "SeparateSAMold"),
                 ],
-                description="Type of chimeric output produced by STAR.",
+                description="Type of chimeric output produced by STAR. If WithinBAM is "
+                "selected, 'WithinBAM HardClip' in the CIGAR is used.",
                 disabled="!detect_chimeric.chimeric",
             )
 

--- a/resolwe_bio/processes/workflows/bbduk_star.py
+++ b/resolwe_bio/processes/workflows/bbduk_star.py
@@ -41,7 +41,7 @@ class WorkflowSTAR(Process):
         "expression-engine": "jinja",
     }
     data_name = "{{ reads|name|default('?') }}"
-    version = "1.6.0"
+    version = "1.7.0"
     entity = {
         "type": "sample",
     }
@@ -210,10 +210,13 @@ class WorkflowSTAR(Process):
                     label="Chimeric output type [--chimOutType]",
                     default="SeparateSAMold",
                     choices=[
-                        ("WithinBam", "WithinBam"),
+                        ("WithinBAM", "WithinBAM"),
+                        ("WithinBAM HardClip", "WithinBAM HardClip"),
+                        ("WithinBAM SoftClip", "WithinBAM SoftClip"),
                         ("SeparateSAMold", "SeparateSAMold"),
                     ],
-                    description="Type of chimeric output produced by STAR.",
+                    description="Type of chimeric output produced by STAR. If WithinBAM is "
+                    "selected, 'WithinBAM HardClip' in the CIGAR is used.",
                     disabled="!alignment.chimeric_reads.chimeric",
                 )
 


### PR DESCRIPTION
This PR fixes the incorrectly typed `WithinBam` parameter (correctly typed is `WithinBAM` and adds two more explicit options for soft/hard clipping.

If only `WithinBAM` is used, `WithinBAM HardClip` is assumed and the `WithinBAM SoftClip` option was added for greater flexibility.


## Checklist
<!--
Mark an `[x]` for completed items.
-->

* [ ] Update CHANGELOG.rst for each commit separately:
  * Pay attention to write entries under the "Unreleased" section.
  * Mark all breaking changes as "**BACKWARD INCOMPATIBLE:**" and put them
    before non-breaking changes.
  * If a commit modifies a feature listed under "Unreleased" section,
    it might be sufficient to modify the existing CHANGELOG entry from previous
    commit(s).
* [x] Bump the process version:
  * **MAJOR version (first number)**: Backward incompatible changes (changes
    that break the api/interface). Examples: renaming the input/output, adding
    mandatory input, removing input/output...
  * **MINOR version (middle number)**: add functionality or changes in a
    backwards-compatible manner. Examples: add output field, add non-mandatory
    input parameter, use a different tool that produces same results...
  * **PATCH version (last number)**: changes/bug fixes that do not affect
    the api/interface. Examples: typo fix, change/add warning messages...
* [x] All inputs are used in process.
* [x] All output fields have a value assigned to them.
