### PR TITLE
Fix --numberOfProcessors in calculate-bigwig

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -24,7 +24,7 @@ Changed
 
 Fixed
 -----
-
+- Fix ``--numberOfProcessors`` input in ``calculate-bigwig`` process
 
 ===================
 59.0.0 - 2024-08-19

--- a/resolwe_bio/processes/support_processors/bam_conversion.py
+++ b/resolwe_bio/processes/support_processors/bam_conversion.py
@@ -99,7 +99,7 @@ class CalculateBigWig(Process):
         "resources": {"cores": 16, "memory": 16384},
     }
     data_name = "{{ alignment|name|default('?') }}"
-    version = "2.1.0"
+    version = "2.1.1"
     process_type = "data:coverage:bigwig"
     category = "BAM processing"
     entity = {"type": "sample"}
@@ -209,7 +209,7 @@ class CalculateBigWig(Process):
             "--outFileName",
             out_file,
             "--numberOfProcessors",
-            self.requirements.resources.cores,
+            int(self.requirements.resources.cores),
             "--outFileFormat",
             "bigwig",
             "--binSize",


### PR DESCRIPTION
* [x] Update CHANGELOG.rst for each commit separately:
  * Pay attention to write entries under the "Unreleased" section.
  * Mark all breaking changes as "**BACKWARD INCOMPATIBLE:**" and put them
    before non-breaking changes.
  * If a commit modifies a feature listed under "Unreleased" section,
    it might be sufficient to modify the existing CHANGELOG entry from previous
    commit(s).
* [x] Bump the process version:
  * **MAJOR version (first number)**: Backward incompatible changes (changes
    that break the api/interface). Examples: renaming the input/output, adding
    mandatory input, removing input/output...
  * **MINOR version (middle number)**: add functionality or changes in a
    backwards-compatible manner. Examples: add output field, add non-mandatory
    input parameter, use a different tool that produces same results...
  * **PATCH version (last number)**: changes/bug fixes that do not affect
    the api/interface. Examples: typo fix, change/add warning messages...
* [x] All inputs are used in process.
* [x] All output fields have a value assigned to them.
