### PR TITLE
Do not force pre-release versions of resolwe

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,8 +44,7 @@ setuptools.setup(
         "Django~=4.2",
         "djangorestframework~=3.15.2",
         "django-filter~=24.2",
-        # XXX: Required due to issue https://github.com/pypa/pip/issues/4905.
-        "resolwe >=42.0a1, ==42.*",
+        "resolwe==42.*",
         "wrapt~=1.16.0",
     ),
     extras_require={


### PR DESCRIPTION
Prevents installing prereleases when no `--pre` flag is given to pip install. Pull request changes this behavior:
```
$ cat requirements-pre.txt 
resolwe>=42.0a1, ==42.*
$ pip install -r requirements-pre.txt
$ pip freeze | grep -i resolwe                                                                                                                                                                        
resolwe==42.1.0a3
```
to this behavior:
```
$ cat requirements-stable.txt                                                                                                                                                                                                 
resolwe==42.*
$ pip install -r requirements-stable.txt
$ pip freeze | grep -i resolwe                                                                                                                                                                       
resolwe==42.0.2
$ pip uninstall resolwe

$ pip install --pre -r requirements-stable.txt
$ pip freeze | grep -i resolwe                                                                                                                                                                        
resolwe==42.1.0a3
```

Tested with Python3.11 and Pip 24.3.1