### PR TITLE
Fix the disabling of BAM writer input

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -28,6 +28,7 @@ Fixed
 -----
 - Optimize ``variant-annotation`` process to handle a larger
   number of variants
+- Fix the disabling of BAM writer input in ``vc-gatk4-hc``
 
 
 ===================

--- a/resolwe_bio/processes/variant_calling/gatk4_hc.py
+++ b/resolwe_bio/processes/variant_calling/gatk4_hc.py
@@ -36,7 +36,7 @@ class GatkHaplotypeCaller(Process):
     name = "GATK4 (HaplotypeCaller)"
     category = "GATK"
     process_type = "data:variants:vcf:gatk:hc"
-    version = "1.6.0"
+    version = "1.6.1"
     scheduling_class = SchedulingClass.BATCH
     entity = {"type": "sample"}
     requirements = {
@@ -132,7 +132,7 @@ class GatkHaplotypeCaller(Process):
                     ("ALL_POSSIBLE_HAPLOTYPES", "All considered haplotypes"),
                     ("NO_HAPLOTYPES", "Do not output haplotypes"),
                 ],
-                disabled="!bam_out",
+                disabled="!advanced.bam_out",
             )
             max_mnp_distance = IntegerField(
                 label="Max MNP distance",


### PR DESCRIPTION
in ``vc-gatk4-hc``

* [x] Update CHANGELOG.rst for each commit separately:
  * Pay attention to write entries under the "Unreleased" section.
  * Mark all breaking changes as "**BACKWARD INCOMPATIBLE:**" and put them
    before non-breaking changes.
  * If a commit modifies a feature listed under "Unreleased" section,
    it might be sufficient to modify the existing CHANGELOG entry from previous
    commit(s).
* [x] Bump the process version:
  * **MAJOR version (first number)**: Backward incompatible changes (changes
    that break the api/interface). Examples: renaming the input/output, adding
    mandatory input, removing input/output...
  * **MINOR version (middle number)**: add functionality or changes in a
    backwards-compatible manner. Examples: add output field, add non-mandatory
    input parameter, use a different tool that produces same results...
  * **PATCH version (last number)**: changes/bug fixes that do not affect
    the api/interface. Examples: typo fix, change/add warning messages...
* [x] All inputs are used in process.
* [x] All output fields have a value assigned to them.